### PR TITLE
fix: note スキ数取得を RSS から公式 API v2 に切り替え

### DIFF
--- a/backend/app/services/blog/collector.py
+++ b/backend/app/services/blog/collector.py
@@ -1,7 +1,7 @@
 """Zenn / note からブログ記事を取得するサービス。"""
 
+import asyncio
 import logging
-import xml.etree.ElementTree as ET
 
 import httpx
 
@@ -62,62 +62,58 @@ async def fetch_zenn_articles(username: str) -> list[dict]:
 
 
 async def fetch_note_articles(username: str) -> list[dict]:
-    """note の RSS フィードから記事を取得する。"""
+    """note API v2 から記事を取得する。全ページ分をフェッチ。"""
     articles: list[dict] = []
+    page = 1
+    headers = {"User-Agent": "DevForge/1.0"}
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.get(f"https://note.com/{username}/rss")
-        resp.raise_for_status()
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        while True:
+            resp = await client.get(
+                f"https://note.com/api/v2/creators/{username}/contents",
+                params={"kind": "note", "page": page},
+            )
+            resp.raise_for_status()
+            data = resp.json()
 
-    root = ET.fromstring(resp.text)
-    channel = root.find("channel")
-    if channel is None:
-        return articles
+            notes = data.get("data", {}).get("contents", [])
+            if not notes:
+                break
 
-    for item in channel.findall("item"):
-        title = item.findtext("title", "")
-        link = item.findtext("link", "")
-        pub_date = item.findtext("pubDate", "")
-        description = item.findtext("description", "")
+            for item in notes:
+                note_url = item.get("noteUrl", "")
+                external_id = str(item.get("id", ""))
+                published_at = (
+                    item.get("publishAt", "")[:10] if item.get("publishAt") else None
+                )
+                hashtags = item.get("hashtags", [])
+                tag_names = [
+                    h.get("hashtag", {}).get("name", "")
+                    for h in hashtags
+                    if isinstance(h, dict)
+                ]
+                body = item.get("body") or ""
 
-        published_at = _parse_rss_date(pub_date)
-        external_id = link.rstrip("/").split("/")[-1] if link else ""
-        tags = [cat.text for cat in item.findall("category") if cat.text]
+                articles.append(
+                    {
+                        "platform": "note",
+                        "external_id": external_id,
+                        "title": item.get("name", ""),
+                        "url": note_url,
+                        "published_at": published_at,
+                        "likes_count": item.get("likeCount", 0),
+                        "summary": body[:500],
+                        "tags": [t for t in tag_names if t],
+                    }
+                )
 
-        articles.append(
-            {
-                "platform": "note",
-                "external_id": external_id,
-                "title": title,
-                "url": link,
-                "published_at": published_at,
-                "likes_count": 0,
-                "summary": _strip_html(description)[:500] if description else "",
-                "tags": tags,
-            }
-        )
+            is_last_page = data.get("data", {}).get("isLastPage", True)
+            if is_last_page:
+                break
+            page += 1
+            await asyncio.sleep(0.5)
 
     return articles
-
-
-def _parse_rss_date(date_str: str) -> str | None:
-    """RSS の日付文字列を YYYY-MM-DD 形式に変換する。"""
-    if not date_str:
-        return None
-    try:
-        from email.utils import parsedate_to_datetime
-
-        dt = parsedate_to_datetime(date_str)
-        return dt.strftime("%Y-%m-%d")
-    except Exception:
-        return date_str[:10] if len(date_str) >= 10 else None
-
-
-def _strip_html(text: str) -> str:
-    """HTMLタグを除去する。"""
-    import re
-
-    return re.sub(r"<[^>]+>", "", text).strip()
 
 
 async def verify_user_exists(platform: str, username: str) -> bool:
@@ -129,7 +125,10 @@ async def verify_user_exists(platform: str, username: str) -> bool:
                 return resp.status_code == 200
         if platform == "note":
             async with httpx.AsyncClient(timeout=10.0) as client:
-                resp = await client.get(f"https://note.com/{username}/rss")
+                resp = await client.get(
+                    f"https://note.com/api/v2/creators/{username}/contents",
+                    params={"kind": "note", "page": 1},
+                )
                 return resp.status_code == 200
         raise UnsupportedBlogPlatformError(platform)
     except (httpx.ConnectError, httpx.TimeoutException):

--- a/backend/tests/test_blog_collector.py
+++ b/backend/tests/test_blog_collector.py
@@ -1,7 +1,6 @@
 """ブログコレクター（fetch_note_articles / fetch_zenn_articles / verify_user_exists）のユニットテスト。"""
 
 import asyncio
-import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -27,41 +26,30 @@ def _run(coro):
 # ── fetch_note_articles テスト ───────────────────────────────────────────
 
 
-def _build_rss(items: list[dict]) -> str:
-    """RSS フィード XML 文字列を構築するヘルパー。"""
-    channel = ET.Element("channel")
-    for item_data in items:
-        item = ET.SubElement(channel, "item")
-        for tag, text in item_data.items():
-            if tag == "categories":
-                for cat_text in text:
-                    cat = ET.SubElement(item, "category")
-                    cat.text = cat_text
-            else:
-                el = ET.SubElement(item, tag)
-                el.text = text
-    root = ET.Element("rss")
-    root.append(channel)
-    return ET.tostring(root, encoding="unicode")
+def _note_api_response(contents: list[dict], *, is_last_page: bool = True) -> dict:
+    """note API v2 のレスポンス JSON を構築するヘルパー。"""
+    return {"data": {"contents": contents, "isLastPage": is_last_page}}
 
 
-def test_fetch_note_articles_no_category_returns_empty_tags() -> None:
-    """RSS の category なし → tags が空リストになること。"""
-    rss_xml = _build_rss(
+def test_fetch_note_articles_no_hashtags_returns_empty_tags() -> None:
+    """hashtags なし → tags が空リストになること。"""
+    api_json = _note_api_response(
         [
             {
-                "title": "テスト記事",
-                "link": "https://note.com/user/n/abc123",
-                "pubDate": "Thu, 01 Jan 2026 00:00:00 +0000",
-                "description": "<p>本文</p>",
-                # category なし
+                "id": 123,
+                "name": "テスト記事",
+                "noteUrl": "https://note.com/user/n/abc123",
+                "publishAt": "2026-01-01T00:00:00.000+0900",
+                "likeCount": 5,
+                "body": "本文テキスト",
+                "hashtags": [],
             }
         ]
     )
 
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
-    mock_resp.text = rss_xml
+    mock_resp.json = MagicMock(return_value=api_json)
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_resp)
@@ -73,25 +61,32 @@ def test_fetch_note_articles_no_category_returns_empty_tags() -> None:
 
     assert len(articles) == 1
     assert articles[0]["tags"] == []
+    assert articles[0]["likes_count"] == 5
+    assert articles[0]["external_id"] == "123"
 
 
-def test_fetch_note_articles_with_categories() -> None:
-    """RSS の category あり → tags に反映されること。"""
-    rss_xml = _build_rss(
+def test_fetch_note_articles_with_hashtags() -> None:
+    """hashtags あり → tags に反映されること。"""
+    api_json = _note_api_response(
         [
             {
-                "title": "Python記事",
-                "link": "https://note.com/user/n/abc456",
-                "pubDate": "Thu, 01 Jan 2026 00:00:00 +0000",
-                "description": "概要",
-                "categories": ["Python", "FastAPI"],
+                "id": 456,
+                "name": "Python記事",
+                "noteUrl": "https://note.com/user/n/abc456",
+                "publishAt": "2026-01-01T00:00:00.000+0900",
+                "likeCount": 42,
+                "body": "概要",
+                "hashtags": [
+                    {"hashtag": {"name": "Python"}},
+                    {"hashtag": {"name": "FastAPI"}},
+                ],
             }
         ]
     )
 
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
-    mock_resp.text = rss_xml
+    mock_resp.json = MagicMock(return_value=api_json)
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_resp)
@@ -102,6 +97,7 @@ def test_fetch_note_articles_with_categories() -> None:
         articles = _run(fetch_note_articles("user"))
 
     assert articles[0]["tags"] == ["Python", "FastAPI"]
+    assert articles[0]["likes_count"] == 42
 
 
 # ── fetch_zenn_articles テスト ───────────────────────────────────────────


### PR DESCRIPTION
note の記事取得を RSS フィードから note.com API v2 に変更し、
likeCount フィールドを正しく likes_count にマッピングするようにした。
RSS では likes_count が常に 0 だったため、ブログスコアの reaction_rank が 正確に算出されていなかった。