### PR TITLE
feat: GitHub 分析パイプラインに AI 学習アドバイス生成を統合

### DIFF
--- a/backend/app/services/tasks/worker.py
+++ b/backend/app/services/tasks/worker.py
@@ -48,7 +48,7 @@ def _now() -> datetime:
 
 
 async def _run_github_analysis(db: Session, payload: dict) -> None:
-    """GitHub 分析パイプラインを実行し、結果をキャッシュに保存する。"""
+    """GitHub 分析パイプラインを実行し、AI 学習アドバイスまで一括生成してキャッシュに保存する。"""
     from ...core.encryption import decrypt_field
     from ...services.intelligence.github_collector import GitHubUserNotFoundError
     from ...services.intelligence.pipeline import run_pipeline
@@ -78,12 +78,38 @@ async def _run_github_analysis(db: Session, payload: dict) -> None:
         raise exc
 
     response = map_pipeline_result(result)
-    cache.analysis_result = response.model_dump()
-    cache.position_advice = None
+    analysis_dict = response.model_dump()
+    cache.analysis_result = analysis_dict
+
+    # LLM が利用可能なら学習アドバイスも自動生成する
+    advice = await _generate_advice_if_available(analysis_dict)
+    cache.position_advice = advice
+
     cache.status = "completed"
     cache.error_message = None
     cache.completed_at = _now()
     db.commit()
+
+
+async def _generate_advice_if_available(analysis: dict) -> str | None:
+    """LLM が利用可能であれば学習アドバイスを生成する。失敗時は None を返す。"""
+    from ...services.intelligence.llm_summarizer import generate_learning_advice
+
+    try:
+        llm_client = get_llm_client()
+        if not await llm_client.check_available():
+            logger.info("LLM が利用できないため学習アドバイスの生成をスキップしました")
+            return None
+
+        scores = analysis.get("position_scores")
+        if not scores:
+            return None
+
+        advice = await generate_learning_advice(analysis, scores)
+        return advice if advice else None
+    except Exception:
+        logger.warning("学習アドバイスの生成に失敗しましたが、分析結果は保存します", exc_info=True)
+        return None
 
 
 # ---------- ブログ AI サマリ ----------

--- a/frontend/src/api/intelligence.ts
+++ b/frontend/src/api/intelligence.ts
@@ -23,11 +23,6 @@ export interface AnalysisResponse {
   position_scores: PositionScores | null;
 }
 
-export interface PositionAdviceResponse {
-  advice: string;
-  available: boolean;
-}
-
 export interface CachedAnalysisResponse {
   analysis_result: AnalysisResponse | null;
   position_advice: string | null;
@@ -42,15 +37,6 @@ export function analyzeGitHub(payload: AnalyzeGitHubPayload): Promise<{ status: 
   return request<{ status: string }>("/api/intelligence/analyze", {
     method: "POST",
     body: JSON.stringify(payload),
-  });
-}
-
-/**
- * ポジションスコアに基づく現状分析+学習アドバイスを取得します。
- */
-export function getPositionAdvice(): Promise<PositionAdviceResponse> {
-  return request<PositionAdviceResponse>("/api/intelligence/position-advice", {
-    method: "POST",
   });
 }
 

--- a/frontend/src/components/analysis/PositionRadarChart.tsx
+++ b/frontend/src/components/analysis/PositionRadarChart.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { marked } from "marked";
 import {
   RadarChart,
@@ -9,10 +9,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import {
-  getPositionAdvice,
-  type PositionScores,
-} from "../../api";
+import type { PositionScores } from "../../api";
 import styles from "./PositionRadarChart.module.css";
 
 interface Props {
@@ -33,37 +30,14 @@ const AXIS_LABELS: Record<string, string> = {
  * フルスタックへのギャップ分析とAI現状分析+学習アドバイスを提供するコンポーネント。
  */
 export function PositionRadarChart({ scores, cachedAdvice }: Props) {
-  const [advice, setAdvice] = useState<string | null>(cachedAdvice ?? null);
-  const [adviceLoading, setAdviceLoading] = useState(false);
-
   const chartData = Object.entries(AXIS_LABELS).map(([key, label]) => ({
     axis: label,
     score: scores[key as keyof PositionScores] as number,
   }));
 
   const adviceHtml = useMemo(() => {
-    if (!advice) return "";
-    return marked.parse(advice, { async: false }) as string;
-  }, [advice]);
-
-  const handleGetAdvice = async () => {
-    setAdviceLoading(true);
-    try {
-      const res = await getPositionAdvice();
-      if (res.available) {
-        setAdvice(res.advice);
-      }
-    } catch {
-      // エラー時は何もしない
-    } finally {
-      setAdviceLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (cachedAdvice) {
-      setAdvice(cachedAdvice);
-    }
+    if (!cachedAdvice) return "";
+    return marked.parse(cachedAdvice, { async: false }) as string;
   }, [cachedAdvice]);
 
   return (
@@ -137,23 +111,14 @@ export function PositionRadarChart({ scores, cachedAdvice }: Props) {
       )}
 
       {/* AI 現状分析 + 学習アドバイス */}
-      <div className={styles.adviceSection}>
-        {advice ? (
+      {cachedAdvice && (
+        <div className={styles.adviceSection}>
           <div
             className={styles.adviceContent}
             dangerouslySetInnerHTML={{ __html: adviceHtml }}
           />
-        ) : (
-          <button
-            type="button"
-            className={styles.adviceButton}
-            onClick={handleGetAdvice}
-            disabled={adviceLoading}
-          >
-            {adviceLoading ? "分析・アドバイス生成中..." : "AI分析 & 学習アドバイスを取得"}
-          </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
「分析開始」ボタン一つで GitHub データ収集から AI 学習アドバイス生成
まで一括実行されるようにした。従来は分析結果表示後に別ボタンで
AI アドバイスを取得する必要があったが、パイプライン内で自動生成し
結果と一緒にキャッシュに保存する。LLM 未利用環境では分析結果のみ
表示し、アドバイスはスキップされる。