### PR TITLE
feat: Redux Toolkit でフォーム状態をページ遷移間で保持

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,11 @@
     "format:check": "prettier --check src/"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.11.2",
     "marked": "^17.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0"
   },

--- a/frontend/src/components/forms/BasicInfoForm.tsx
+++ b/frontend/src/components/forms/BasicInfoForm.tsx
@@ -32,6 +32,7 @@ export function BasicInfoForm() {
     buildPayload: buildBasicPayload,
     mapResponseToForm: mapBasicInfoToForm,
     successMessage: "基本情報を保存しました。",
+    cacheKey: "basicInfo",
   });
 
   const onChangeField = (key: BasicTextFieldKey, value: string) => {

--- a/frontend/src/components/forms/CareerResumeForm.tsx
+++ b/frontend/src/components/forms/CareerResumeForm.tsx
@@ -60,6 +60,7 @@ export function CareerResumeForm() {
     mapResponseToForm: mapCareerResumeToForm,
     successMessage: "職務経歴書を保存しました。PDF出力できます。",
     beforeSave: assertBasicInfoReady,
+    cacheKey: "career",
   });
 
   const { items: techStackOptions } = useTechnologyStacks();

--- a/frontend/src/components/forms/ResumeForm.tsx
+++ b/frontend/src/components/forms/ResumeForm.tsx
@@ -52,6 +52,7 @@ export function ResumeForm() {
     mapResponseToForm: mapResumeToForm,
     successMessage: "履歴書を保存しました。PDF出力できます。",
     beforeSave: assertBasicInfoReady,
+    cacheKey: "resume",
   });
 
   const {

--- a/frontend/src/hooks/useDocumentForm.ts
+++ b/frontend/src/hooks/useDocumentForm.ts
@@ -1,4 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAppDispatch, useAppSelector } from "../store";
+import { clearCache, setCache, type FormCacheKey } from "../store/formCacheSlice";
 
 type UseDocumentFormOptions<FormState, Payload, Response extends { id: string }> = {
   createInitialForm: () => FormState;
@@ -10,6 +13,8 @@ type UseDocumentFormOptions<FormState, Payload, Response extends { id: string }>
   mapResponseToForm: (response: Response) => FormState;
   successMessage: string;
   beforeSave?: () => Promise<void>;
+  /** 指定するとページ遷移してもフォーム状態が Redux ストアに保持される */
+  cacheKey?: FormCacheKey;
 };
 
 export function useDocumentForm<FormState, Payload, Response extends { id: string }>({
@@ -22,47 +27,95 @@ export function useDocumentForm<FormState, Payload, Response extends { id: strin
   mapResponseToForm,
   successMessage,
   beforeSave,
+  cacheKey,
 }: UseDocumentFormOptions<FormState, Payload, Response>) {
-  const [form, setForm] = useState<FormState>(() => createInitialForm());
-  const [documentId, setDocumentId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const dispatch = useAppDispatch();
+  const cached = useAppSelector((s) =>
+    cacheKey ? s.formCache[cacheKey] : undefined,
+  );
+
+  const [form, setFormRaw] = useState<FormState>(() => {
+    if (cached?.form) return cached.form as FormState;
+    return createInitialForm();
+  });
+  const [documentId, setDocumentId] = useState<string | null>(
+    cached?.documentId ?? null,
+  );
+  const [loading, setLoading] = useState(!cached);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
+  /** キャッシュキーを ref で保持（dispatch 時の最新値参照用） */
+  const cacheKeyRef = useRef(cacheKey);
+  cacheKeyRef.current = cacheKey;
+
+  /** setForm のラッパー: Redux キャッシュも同時更新する */
+  const setForm: React.Dispatch<React.SetStateAction<FormState>> = useCallback(
+    (action) => {
+      setFormRaw((prev) => {
+        const next = typeof action === "function" ? (action as (prev: FormState) => FormState)(prev) : action;
+        if (cacheKeyRef.current) {
+          // documentId は現在の state から直接取れないため ref 不要、
+          // setDocumentId は setForm と同タイミングで呼ばれるので後続の updateCache で上書きされる
+          dispatch(
+            setCache({
+              key: cacheKeyRef.current,
+              form: next,
+              documentId: null, // 後で updateCache で正確な値に上書き
+            }),
+          );
+        }
+        return next;
+      });
+    },
+    [dispatch],
+  );
+
+  /** フォームと documentId を同時に Redux キャッシュに反映する */
+  const updateCache = useCallback(
+    (formData: FormState, docId: string | null) => {
+      if (cacheKeyRef.current) {
+        dispatch(
+          setCache({ key: cacheKeyRef.current, form: formData, documentId: docId }),
+        );
+      }
+    },
+    [dispatch],
+  );
+
   useEffect(() => {
+    // キャッシュが既にある場合は API ロードをスキップ
+    if (cached) return;
+
     let active = true;
     setLoading(true);
 
     (async () => {
       try {
         const latest = await loadLatest();
-        if (!active) {
-          return;
-        }
+        if (!active) return;
         setDocumentId(latest.id);
-        setForm(mapResponseToForm(latest));
+        const mapped = mapResponseToForm(latest);
+        setFormRaw(mapped);
+        updateCache(mapped, latest.id);
       } catch {
-        if (!active) {
-          return;
-        }
+        if (!active) return;
       } finally {
-        if (active) {
-          setLoading(false);
-        }
+        if (active) setLoading(false);
       }
     })();
 
     return () => {
       active = false;
     };
-  }, [loadLatest, mapResponseToForm]);
+    // cached を依存配列に含めないことで、キャッシュ更新のたびに再 fetch しない
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadLatest, mapResponseToForm, updateCache]);
 
   const saveButtonText = useMemo(() => {
-    if (saving) {
-      return "保存中...";
-    }
+    if (saving) return "保存中...";
     return documentId ? "更新する" : "保存する";
   }, [documentId, saving]);
 
@@ -72,19 +125,21 @@ export function useDocumentForm<FormState, Payload, Response extends { id: strin
     setSuccess(null);
 
     try {
-      if (beforeSave) {
-        await beforeSave();
-      }
+      if (beforeSave) await beforeSave();
       const payload = buildPayload(form);
       const saved = documentId
         ? await updateDocument(documentId, payload)
         : await createDocument(payload);
+      const mapped = mapResponseToForm(saved);
       setDocumentId(saved.id);
-      setForm(mapResponseToForm(saved));
+      setFormRaw(mapped);
+      updateCache(mapped, saved.id);
       setSuccess(successMessage);
     } catch (submitError) {
       const message =
-        submitError instanceof Error ? submitError.message : "保存中に不明なエラーが発生しました。";
+        submitError instanceof Error
+          ? submitError.message
+          : "保存中に不明なエラーが発生しました。";
       setError(message);
     } finally {
       setSaving(false);
@@ -99,11 +154,17 @@ export function useDocumentForm<FormState, Payload, Response extends { id: strin
     try {
       const result = await deleteDocument();
       setDocumentId(null);
-      setForm(createInitialForm());
+      const initial = createInitialForm();
+      setFormRaw(initial);
+      if (cacheKeyRef.current) {
+        dispatch(clearCache(cacheKeyRef.current));
+      }
       setSuccess(result.message);
     } catch (deleteError) {
       const message =
-        deleteError instanceof Error ? deleteError.message : "削除中に不明なエラーが発生しました。";
+        deleteError instanceof Error
+          ? deleteError.message
+          : "削除中に不明なエラーが発生しました。";
       setError(message);
     } finally {
       setDeleting(false);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 import ErrorBoundary from "./components/ErrorBoundary";
+import { store } from "./store";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <ErrorBoundary>
-        <App />
-      </ErrorBoundary>
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
 );

--- a/frontend/src/store/formCacheSlice.ts
+++ b/frontend/src/store/formCacheSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+/** フォームキャッシュのキー。各フォームページに対応。 */
+export type FormCacheKey = "basicInfo" | "resume" | "career";
+
+interface FormCacheEntry {
+  /** フォーム状態（型は各フォームに依存するため unknown） */
+  form: unknown;
+  /** 保存済みドキュメント ID（未保存なら null） */
+  documentId: string | null;
+}
+
+type FormCacheState = Record<string, FormCacheEntry | undefined>;
+
+const formCacheSlice = createSlice({
+  name: "formCache",
+  initialState: {} as FormCacheState,
+  reducers: {
+    setCache(
+      state,
+      action: PayloadAction<{
+        key: FormCacheKey;
+        form: unknown;
+        documentId: string | null;
+      }>,
+    ) {
+      const { key, form, documentId } = action.payload;
+      state[key] = { form, documentId };
+    },
+    clearCache(state, action: PayloadAction<FormCacheKey>) {
+      delete state[action.payload];
+    },
+  },
+});
+
+export const { setCache, clearCache } = formCacheSlice.actions;
+export default formCacheSlice.reducer;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,15 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { useDispatch, useSelector, type TypedUseSelectorHook } from "react-redux";
+import formCacheReducer from "./formCacheSlice";
+
+export const store = configureStore({
+  reducer: {
+    formCache: formCacheReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
useDocumentForm に cacheKey オプションを追加し、ページ遷移しても
フォームの入力内容が Redux ストアに保持されるようにした。
キャッシュが存在する場合は API ロードをスキップし、即座に前回の
入力状態を復元する。保存・削除時にキャッシュも同期される。