### PR TITLE
docs: CONTRIBUTING.md に ADR 運用ルールを追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -79,3 +79,15 @@ VERTEX_MODEL         # 例: gemini-2.5-flash-lite
 ## スコープ別ルール
 
 バックエンド・フロントエンド・インフラ固有のルール（アーキテクチャ、DB設計、認証、LLM統合等）は `.claude/rules/` に分割済み。対象パスのファイルを編集する際に自動でロードされる。
+
+## ADR（Architecture Decision Record）
+
+技術選定・アーキテクチャ判断を行う際は必ず `docs/adr/` を確認し、
+既存の判断と矛盾しない実装を行うこと。
+
+新たに重要な技術判断を行う場合は `CONTRIBUTING.md` の ADR 運用ルールに従い、
+ADR を作成してから実装を開始すること。
+
+- ADR 一覧: `docs/adr/`
+- テンプレート: `docs/adr/0000-template.md`
+- 運用ルール: `CONTRIBUTING.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing Guide
+
+## ブランチ戦略
+
+| ブランチ | 用途 |
+|---|---|
+| `main` | 本番リリース済みコード |
+| `develop` | 開発統合ブランチ |
+| `feature/*` | 機能開発 |
+| `fix/*` | バグ修正 |
+| `docs/*` | ドキュメント変更 |
+| `refactor/*` | リファクタリング |
+| `infra/*` | インフラ変更 |
+
+## PR の作り方
+
+- `develop` ブランチに向けて PR を作成する
+- PR タイトルは `: <内容>` の形式（例: `feat: GitHub 分析スコア計算の追加`）
+- セルフレビュー後にマージする
+
+## ADR（Architecture Decision Record）
+
+### ADR とは
+
+技術選定・アーキテクチャ上の重要な判断を記録するドキュメントです。
+「なぜその技術を選んだか」「どんな代替案を検討したか」「既知のリスクは何か」を残すことで、
+将来の自分や開発者が設計意図を理解できるようにします。
+
+### ADR を書くべきタイミング
+
+以下のいずれかに該当する判断を行った場合は ADR を作成してください。
+
+- 新しいライブラリ・サービス・インフラを採用するとき
+- 既存の技術スタックを変更・廃止するとき
+- セキュリティ・コスト・パフォーマンスに影響するアーキテクチャ判断を行うとき
+- 「なぜこうしたのか」を後から説明する必要がありそうな判断をするとき
+
+迷ったら書く。小さすぎる判断に ADR は不要ですが、書きすぎて困ることはありません。
+
+### ファイル命名規則
+
+```
+docs/adr/XXXX-kebab-case-title.md
+```
+
+- `XXXX` は4桁の連番（例: `0006`）
+- タイトルは英語のケバブケース
+- テンプレート: `docs/adr/0000-template.md`
+
+### ステータスの運用
+
+| ステータス | 意味 |
+|---|---|
+| `Proposed` | 提案中・レビュー待ち |
+| `Accepted` | 採用済み・現在有効 |
+| `Deprecated` | 廃止済み（理由を本文に記載） |
+| `Superseded by ADR-XXXX` | 別の ADR に置き換えられた |
+
+### 既存 ADR を更新する場合
+
+既存の判断を覆す場合は既存の ADR を直接編集せず、新しい ADR を作成してください。
+
+1. 新しい ADR を作成し、ステータスを `Accepted` にする
+2. 古い ADR のステータスを `Superseded by ADR-XXXX` に変更する
+3. 古い ADR の本文末尾に変更の経緯を一行追記する
+
+### 既存の ADR 一覧
+
+| No. | タイトル | ステータス |
+|---|---|---|
+| [ADR-0001](docs/adr/0001-sqlite-gcs-backup.md) | SQLite + GCS バックアップ方式の採用 | Accepted |
+| [ADR-0002](docs/adr/0002-jwt-cookie-auth.md) | JWT + Cookie 認証方式の採用 | Accepted |
+| [ADR-0003](docs/adr/0003-redux-toolkit-persist.md) | Redux Toolkit + redux-persist の採用 | Accepted |
+| [ADR-0004](docs/adr/0004-llm-provider-abstraction.md) | LLM プロバイダ抽象化（Ollama/Vertex AI） | Accepted |
+| [ADR-0005](docs/adr/0005-cloudrun-single-instance.md) | Cloud Run single instance 構成の採用 | Accepted |


### PR DESCRIPTION
## 概要

ADR 運用ルールをドキュメント化し、Claude Code のガイドラインに参照を追記する。

## 変更内容

- `CONTRIBUTING.md` を新規作成（ブランチ戦略・PR 運用・ADR 運用ルール）
- `.claude/CLAUDE.md` 末尾に ADR セクションを追記

## 関連 Issue

なし

## 確認事項

- [ ] CI が通ること
- [ ] 動作確認済み