### PR TITLE
feat: LLM 処理失敗をフロントエンドに伝達する仕組みの実装 (#185)

### DIFF
--- a/backend/app/services/intelligence/llm/base.py
+++ b/backend/app/services/intelligence/llm/base.py
@@ -7,8 +7,8 @@ class LLMClient(ABC):
     """LLM バックエンド共通インターフェース。"""
 
     @abstractmethod
-    async def generate(self, system_prompt: str, user_prompt: str) -> str:
-        """テキスト生成を実行する。失敗時は空文字列を返す。"""
+    async def generate(self, system_prompt: str, user_prompt: str) -> str | None:
+        """テキスト生成を実行する。失敗時は None を返す。"""
 
     @abstractmethod
     async def check_available(self) -> bool:

--- a/backend/app/services/intelligence/llm/ollama_client.py
+++ b/backend/app/services/intelligence/llm/ollama_client.py
@@ -23,11 +23,11 @@ class OllamaClient(LLMClient):
         self.model = os.environ.get("OLLAMA_MODEL", "gemma3:4b")
         self.timeout = float(os.environ.get("OLLAMA_TIMEOUT", "1200.0"))  # デフォルトは 20 分
 
-    async def generate(self, system_prompt: str, user_prompt: str) -> str:
+    async def generate(self, system_prompt: str, user_prompt: str) -> str | None:
         """Ollama API でテキスト生成を実行する。
 
         タイムアウト・5xx・429 は ``RetryableError``、4xx は ``NonRetryableError``
-        を raise する。``ConnectError``（Ollama 未起動時）は既存動作を維持し空文字を返す。
+        を raise する。``ConnectError``（Ollama 未起動時）および未分類エラーは ``None`` を返す。
         """
         start = time.monotonic()
         try:
@@ -51,7 +51,7 @@ class OllamaClient(LLMClient):
                 return data.get("response", "").strip()
         except httpx.ConnectError:
             logger.info("Ollama が %s で利用できません", self.base_url)
-            return ""
+            return None
         except httpx.TimeoutException as exc:
             duration_ms = int((time.monotonic() - start) * 1000)
             logger.warning(
@@ -83,7 +83,7 @@ class OllamaClient(LLMClient):
                 "Ollama による生成に失敗しました",
                 extra={"status": "failed", "duration_ms": duration_ms},
             )
-            return ""
+            return None
 
     async def check_available(self) -> bool:
         """Ollama サーバーに接続可能、かつ指定モデルが利用可能か確認する。"""

--- a/backend/app/services/intelligence/llm/vertex_client.py
+++ b/backend/app/services/intelligence/llm/vertex_client.py
@@ -76,11 +76,11 @@ class VertexClient(LLMClient):
             )
         return self._client
 
-    async def generate(self, system_prompt: str, user_prompt: str) -> str:
+    async def generate(self, system_prompt: str, user_prompt: str) -> str | None:
         """Vertex AI Gemini でテキスト生成を実行する。
 
         一時障害は ``RetryableError``、恒久的な障害は ``NonRetryableError`` を
-        raise する。未分類の例外は既存動作（空文字返却）を維持する。
+        raise する。未分類の例外は ``None`` を返す。
         """
         start = time.monotonic()
         try:
@@ -127,7 +127,7 @@ class VertexClient(LLMClient):
                 "Vertex AI による生成に失敗しました",
                 extra={"status": "failed", "duration_ms": duration_ms},
             )
-            return ""
+            return None
 
     async def check_available(self) -> bool:
         """VERTEX_PROJECT_ID が設定されていれば利用可能とみなす。"""

--- a/backend/app/services/intelligence/llm_summarizer.py
+++ b/backend/app/services/intelligence/llm_summarizer.py
@@ -52,11 +52,11 @@ def _build_blog_prompt(
 async def summarize_blog_articles(
     articles: List[Dict[str, Any]],
     context: Optional[SanitizeContext] = None,
-) -> str:
+) -> str | None:
     """ブログ記事一覧から LLM で AI サマリを生成する。
 
     context が指定された場合、記事タイトル・要約を sanitize_text() でマスキングする。
-    LLM に接続できない場合は空文字列を返す。
+    LLM に接続できない場合は None を返す。
     """
     system_prompt = load_prompt("blog_analysis.md")
     prompt = _build_blog_prompt(articles, context)
@@ -110,10 +110,10 @@ def _build_learning_advice_prompt(
 async def generate_learning_advice(
     analysis: Dict[str, Any],
     scores: Dict[str, Any],
-) -> str:
+) -> str | None:
     """分析結果とポジションスコアから現状分析+学習アドバイスを LLM で生成する。
 
-    LLM に接続できない場合は空文字列を返す。
+    LLM に接続できない場合は None を返す。
     """
     system_prompt = load_prompt("github_analysis.md")
     prompt = _build_learning_advice_prompt(analysis, scores)

--- a/backend/app/services/tasks/worker.py
+++ b/backend/app/services/tasks/worker.py
@@ -244,13 +244,13 @@ async def _run_github_analysis(db: Session, payload: dict) -> None:
     cache.analysis_result = analysis_dict
 
     # LLM が利用可能なら学習アドバイスも自動生成する
-    advice = await _generate_advice_if_available(analysis_dict)
+    advice, llm_failed = await _generate_advice_if_available(analysis_dict)
     cache.position_advice = advice
 
     # ステップ 5: DB 保存
     await set_progress(task_id, 5, _TOTAL_STEPS, "結果を保存中...")
     cache.status = "completed"
-    cache.error_message = None
+    cache.error_message = "LLM処理が利用できません" if llm_failed else None
     cache.completed_at = _now()
     db.commit()
 
@@ -258,25 +258,33 @@ async def _run_github_analysis(db: Session, payload: dict) -> None:
     await set_progress(task_id, 6, _TOTAL_STEPS, "完了")
 
 
-async def _generate_advice_if_available(analysis: dict) -> str | None:
-    """LLM が利用可能であれば学習アドバイスを生成する。失敗時は None を返す。"""
+async def _generate_advice_if_available(analysis: dict) -> tuple[str | None, bool]:
+    """LLM が利用可能であれば学習アドバイスを生成する。
+
+    戻り値は (advice, llm_failed) のタプル。
+    llm_failed=True は LLM の呼び出しを試みたが失敗したことを示す。
+    LLM が未設定またはスコア情報がない場合は llm_failed=False でスキップする。
+    """
     from ...services.intelligence.llm_summarizer import generate_learning_advice
 
     try:
         llm_client = get_llm_client()
         if not await llm_client.check_available():
             logger.info("LLM が利用できないため学習アドバイスの生成をスキップしました")
-            return None
+            return None, False
 
         scores = analysis.get("position_scores")
         if not scores:
-            return None
+            return None, False
 
         advice = await generate_learning_advice(analysis, scores)
-        return advice if advice else None
+        if advice is None:
+            logger.warning("LLM が学習アドバイスの生成に失敗しました")
+            return None, True
+        return advice, False
     except Exception:
         logger.warning("学習アドバイスの生成に失敗しましたが、分析結果は保存します", exc_info=True)
-        return None
+        return None, True
 
 
 # ---------- ブログ AI サマリ ----------
@@ -308,7 +316,7 @@ async def _run_blog_summarize(db: Session, payload: dict) -> None:
     summary = await summarize_blog_articles(articles_data)
     if not summary:
         cache.status = "dead_letter"
-        cache.error_message = "AI サマリの生成に失敗しました"
+        cache.error_message = "LLM処理が利用できません"
         cache.completed_at = _now()
         db.commit()
         return

--- a/backend/tests/test_llm_clients.py
+++ b/backend/tests/test_llm_clients.py
@@ -43,7 +43,7 @@ def test_ollama_generate_success():
 
 
 def test_ollama_generate_connect_error():
-    """Ollama 接続エラー時に空文字列を返す。"""
+    """Ollama 接続エラー時に None を返す。"""
     client = OllamaClient()
 
     with patch("httpx.AsyncClient") as mock_cls:
@@ -54,7 +54,7 @@ def test_ollama_generate_connect_error():
         mock_cls.return_value = mock_http
 
         result = _run(client.generate("system", "user"))
-        assert result == ""
+        assert result is None
 
 
 def test_ollama_check_available_success():
@@ -144,7 +144,7 @@ def test_vertex_generate_success():
 
 
 def test_vertex_generate_exception():
-    """Vertex AI で例外発生時に空文字列を返す。"""
+    """Vertex AI で例外発生時に None を返す。"""
     with patch.dict(os.environ, {"VERTEX_PROJECT_ID": "test-project"}):
         client = VertexClient()
 
@@ -158,7 +158,7 @@ def test_vertex_generate_exception():
 
     client._client = mock_genai_client
     result = _run(client.generate("system", "user"))
-    assert result == ""
+    assert result is None
 
 
 def test_vertex_check_available_with_project():

--- a/backend/tests/test_worker_extended.py
+++ b/backend/tests/test_worker_extended.py
@@ -412,17 +412,17 @@ class TestGenerateAdviceIfAvailable:
         }
 
     def test_llm_unavailable_returns_none(self):
-        """LLM が利用不可の場合 None を返すこと。"""
+        """LLM が利用不可の場合 (None, False) を返すこと。"""
         mock_llm = MagicMock()
         mock_llm.check_available = AsyncMock(return_value=False)
 
         with patch("app.services.tasks.worker.get_llm_client", return_value=mock_llm):
             result = _run(_generate_advice_if_available(self._analysis()))
 
-        assert result is None
+        assert result == (None, False)
 
     def test_llm_available_returns_advice(self):
-        """LLM が利用可能の場合、アドバイス文字列を返すこと。"""
+        """LLM が利用可能の場合、(アドバイス文字列, False) を返すこと。"""
         mock_llm = MagicMock()
         mock_llm.check_available = AsyncMock(return_value=True)
 
@@ -436,27 +436,27 @@ class TestGenerateAdviceIfAvailable:
         ):
             result = _run(_generate_advice_if_available(self._analysis()))
 
-        assert result == "学習アドバイスです"
+        assert result == ("学習アドバイスです", False)
 
     def test_llm_exception_returns_none(self):
-        """LLM が例外を送出した場合 None を返し例外が外に漏れないこと。"""
+        """LLM が例外を送出した場合 (None, True) を返し例外が外に漏れないこと。"""
         mock_llm = MagicMock()
         mock_llm.check_available = AsyncMock(side_effect=Exception("LLM クラッシュ"))
 
         with patch("app.services.tasks.worker.get_llm_client", return_value=mock_llm):
             result = _run(_generate_advice_if_available(self._analysis()))
 
-        assert result is None
+        assert result == (None, True)
 
     def test_no_position_scores_returns_none(self):
-        """position_scores が None の場合 None を返すこと。"""
+        """position_scores が None の場合 (None, False) を返すこと。"""
         mock_llm = MagicMock()
         mock_llm.check_available = AsyncMock(return_value=True)
 
         with patch("app.services.tasks.worker.get_llm_client", return_value=mock_llm):
             result = _run(_generate_advice_if_available({"repos_analyzed": 5}))
 
-        assert result is None
+        assert result == (None, False)
 
 
 # ── execute_task (ルーティングロジック) ───────────────────────────────────

--- a/frontend/src/components/analysis/GitHubAnalysisPage.tsx
+++ b/frontend/src/components/analysis/GitHubAnalysisPage.tsx
@@ -25,6 +25,8 @@ export function GitHubAnalysisPage() {
   const [includeForks, setIncludeForks] = useState(false);
   /** ポジションアドバイス（GitHub 固有のキャッシュデータ） */
   const [positionAdvice, setPositionAdvice] = useState<string | null>(null);
+  /** LLM 処理が失敗した場合のエラーコード（部分成功ケース） */
+  const [llmErrorCode, setLlmErrorCode] = useState<string | null>(null);
 
   const {
     phase,
@@ -42,6 +44,8 @@ export function GitHubAnalysisPage() {
       if (cache.position_advice) {
         setPositionAdvice(cache.position_advice);
       }
+      // LLM 処理失敗のエラーコードを保持する（部分成功ケース）
+      setLlmErrorCode(cache.error_code ?? null);
       return { result: cache.analysis_result, status: cache.status };
     },
     checkStatus: getAnalysisCacheStatus,
@@ -54,6 +58,7 @@ export function GitHubAnalysisPage() {
   const handleAnalyze = async () => {
     setError(null);
     setPositionAdvice(null);
+    setLlmErrorCode(null);
     try {
       await analyzeGitHub({ include_forks: includeForks });
       transitionToPolling();
@@ -67,6 +72,7 @@ export function GitHubAnalysisPage() {
    */
   const handleBack = () => {
     setPositionAdvice(null);
+    setLlmErrorCode(null);
     setResult(null);
     backToInput();
   };
@@ -157,6 +163,8 @@ export function GitHubAnalysisPage() {
             onRetry={handleAnalyze}
           />
         )}
+
+        {llmErrorCode && <ErrorToast code={llmErrorCode} />}
 
         {/* 概要 */}
         <div className={styles.section}>


### PR DESCRIPTION
## 概要

`LLMClient.generate()` が失敗時に空文字列を返す設計（ADR-0004）のため、LLM 処理が失敗してもフロントエンドがエラーを検知できない問題を修正。

## 変更内容

- `generate()` の返却型を `str` → `str | None`（失敗時は `None`）に変更
- `OllamaClient` / `VertexClient` で失敗時に `return ""` → `return None` に統一
- `llm_summarizer.py` の返却型を `str | None` に更新（`None` を透過）
- `_generate_advice_if_available()` を `tuple[str | None, bool]` 返却に変更し、LLM 呼び出し失敗時に `llm_failed=True` を返すよう修正
- `_run_github_analysis()` で LLM 失敗時に `cache.error_message = "LLM処理が利用できません"` を設定し、既存の `resolve_async_error_code()` が `LLM_UNAVAILABLE` を解決できるようにした（DB マイグレーション不要）
- `_run_blog_summarize()` のエラーメッセージを `LLM_UNAVAILABLE` パターンに合わせて修正
- `GitHubAnalysisPage.tsx` に LLM 部分失敗時の警告バナー（`ErrorToast`）を追加（分析結果は表示したまま）
- テストを返却型変更・タプル化に対応して更新

## 関連 Issue

closes #185

## 確認事項

- [x] CI が通ること（ruff OK / pytest 366 passed / frontend tests 69 passed / build 成功）
- [x] 動作確認済み（`error_message` → `resolve_async_error_code()` → `LLM_UNAVAILABLE` の解決パスを確認）

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8otqKDkQXhDD2poFi3duB)_