### PR TITLE
 [fix] GitHub OAuth state/redirect を __session cookie に統合し Firebase 転送制限を回避 

### DIFF
--- a/backend/app/routers/auth/endpoints.py
+++ b/backend/app/routers/auth/endpoints.py
@@ -26,8 +26,6 @@ from ...repositories import UserRepository
 from ...schemas import GitHubCallbackRequest, TokenResponse
 from .github_auth import authenticate_github_user
 from .oauth_flow import (
-    GITHUB_OAUTH_REDIRECT_COOKIE,
-    GITHUB_OAUTH_STATE_COOKIE,
     begin_github_oauth,
     build_external_base_url,
     build_frontend_redirect_url,
@@ -37,7 +35,8 @@ from .oauth_flow import (
 )
 from .token_manager import (
     clear_auth_cookies,
-    clear_github_oauth_cookies,
+    clear_github_oauth_session,
+    get_github_oauth_session,
     set_auth_cookies,
 )
 
@@ -180,15 +179,8 @@ async def github_callback_redirect(
     200 + HTML リダイレクトで Cookie を確実にセットする。
     """
 
-    # ===== 一時デバッグログ =====
-    logger.warning("DEBUG callback cookies: %s", dict(request.cookies))
-    logger.warning("DEBUG callback state_param: %s", state)
-    logger.warning("DEBUG callback code: %s", code[:8] if code else None)
-    # ===========================
-
-    frontend_url = resolve_frontend_url_from_cookie(
-        request.cookies.get(GITHUB_OAUTH_REDIRECT_COOKIE)
-    )
+    stored_state, stored_redirect = get_github_oauth_session(request)
+    frontend_url = resolve_frontend_url_from_cookie(stored_redirect)
 
     try:
         if not code:
@@ -198,10 +190,7 @@ async def github_callback_redirect(
                 message=get_error("auth.github_code_missing"),
                 action="GitHub ログインをやり直してください",
             )
-        validate_github_oauth_state(
-            request.cookies.get(GITHUB_OAUTH_STATE_COOKIE),
-            state,
-        )
+        validate_github_oauth_state(stored_state, state)
         callback_base = get_callback_base_url() or build_external_base_url(request)
         redirect_uri = f"{callback_base}/auth/github/callback"
         token_response = await authenticate_github_user(db, code, redirect_uri)
@@ -212,12 +201,12 @@ async def github_callback_redirect(
         response = HTMLResponse(
             content=_html_redirect(build_frontend_redirect_url(frontend_url, error_message))
         )
-        clear_github_oauth_cookies(response)
+        clear_github_oauth_session(response)
         return response
 
     response = HTMLResponse(content=_html_redirect(build_frontend_redirect_url(frontend_url)))
     set_auth_cookies(response, token_response.username, db)
-    clear_github_oauth_cookies(response)
+    clear_github_oauth_session(response)
     return response
 
 
@@ -230,13 +219,11 @@ async def github_callback(
     db: Session = Depends(get_db),
 ) -> TokenResponse:
     """GitHub OAuth コードを受け取り、認証 Cookie を発行する。"""
-    validate_github_oauth_state(
-        request.cookies.get(GITHUB_OAUTH_STATE_COOKIE),
-        payload.state,
-    )
+    stored_state, _ = get_github_oauth_session(request)
+    validate_github_oauth_state(stored_state, payload.state)
     callback_base = get_callback_base_url() or build_external_base_url(request)
     redirect_uri = f"{callback_base}/auth/github/callback"
     token_response = await authenticate_github_user(db, payload.code, redirect_uri)
     set_auth_cookies(response, token_response.username, db)
-    clear_github_oauth_cookies(response)
+    clear_github_oauth_session(response)
     return token_response

--- a/backend/app/routers/auth/oauth_flow.py
+++ b/backend/app/routers/auth/oauth_flow.py
@@ -12,10 +12,9 @@ from ...core.errors import ErrorCode, raise_app_error
 from ...core.messages import get_error
 from ...core.settings import get_callback_base_url, get_cors_origins, get_github_client_id
 from .token_manager import (
-    GITHUB_OAUTH_COOKIE_MAX_AGE,
     GITHUB_OAUTH_REDIRECT_COOKIE,
     GITHUB_OAUTH_STATE_COOKIE,
-    set_cookie,
+    set_github_oauth_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -223,18 +222,7 @@ def begin_github_oauth(
     redirect_uri = f"{callback_base}/auth/github/callback"
     state = secrets.token_urlsafe(32)
 
-    set_cookie(
-        response,
-        GITHUB_OAUTH_STATE_COOKIE,
-        state,
-        GITHUB_OAUTH_COOKIE_MAX_AGE,
-    )
-    set_cookie(
-        response,
-        GITHUB_OAUTH_REDIRECT_COOKIE,
-        frontend_url,
-        GITHUB_OAUTH_COOKIE_MAX_AGE,
-    )
+    set_github_oauth_session(response, state, frontend_url)
 
     return build_github_authorization_url(
         client_id=client_id,

--- a/backend/app/routers/auth/token_manager.py
+++ b/backend/app/routers/auth/token_manager.py
@@ -2,9 +2,10 @@
 Cookie設定・削除・JWT生成・トークン検証を担うモジュール。
 """
 
+import json
 import secrets
 
-from fastapi import Response
+from fastapi import Request, Response
 from sqlalchemy.orm import Session
 
 from ...core.security.auth import (
@@ -22,6 +23,9 @@ from ...repositories import UserRepository
 # GitHub OAuth 用 Cookie 名
 GITHUB_OAUTH_STATE_COOKIE = "github_oauth_state"
 GITHUB_OAUTH_REDIRECT_COOKIE = "github_oauth_redirect"
+# Firebase Hosting は __session という名前の Cookie のみ Cloud Run に転送するため、
+# state と redirect_url を JSON で1つの Cookie にまとめて格納する
+GITHUB_OAUTH_SESSION_COOKIE = "__session"
 GITHUB_OAUTH_COOKIE_MAX_AGE = 10 * 60
 
 
@@ -47,6 +51,40 @@ def clear_github_oauth_cookies(response: Response) -> None:
     """GitHub OAuth フロー用 Cookie をすべて削除する。"""
     delete_cookie(response, GITHUB_OAUTH_STATE_COOKIE)
     delete_cookie(response, GITHUB_OAUTH_REDIRECT_COOKIE)
+
+
+def set_github_oauth_session(
+    response: Response, state: str, redirect_url: str
+) -> None:
+    """GitHub OAuth 用の state と redirect_url を __session cookie に格納する。
+
+    Firebase Hosting は __session という名前の Cookie のみ Cloud Run に転送するため、
+    state と redirect_url を JSON で1つの Cookie にまとめる。
+    """
+    payload = json.dumps({"state": state, "redirect": redirect_url})
+    set_cookie(response, GITHUB_OAUTH_SESSION_COOKIE, payload, GITHUB_OAUTH_COOKIE_MAX_AGE)
+
+
+def get_github_oauth_session(request: Request) -> tuple[str | None, str | None]:
+    """__session cookie から (state, redirect_url) を取り出す。
+
+    取得できない場合は (None, None) を返す。
+    """
+    raw = request.cookies.get(GITHUB_OAUTH_SESSION_COOKIE)
+    if not raw:
+        return None, None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None, None
+    if not isinstance(data, dict):
+        return None, None
+    return data.get("state"), data.get("redirect")
+
+
+def clear_github_oauth_session(response: Response) -> None:
+    """__session cookie を削除する。"""
+    delete_cookie(response, GITHUB_OAUTH_SESSION_COOKIE)
 
 
 def set_auth_cookies(response: Response, username: str, db: Session) -> None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -263,7 +264,7 @@ def test_github_login_url_sets_state_cookie(client) -> None:
 
     assert response.status_code == 200
     assert "https://github.com/login/oauth/authorize" in response.json()["authorization_url"]
-    assert "github_oauth_state=" in response.headers["set-cookie"]
+    assert "__session=" in response.headers["set-cookie"]
 
 
 def test_github_login_url_uses_forwarded_https_scheme(client) -> None:
@@ -313,15 +314,17 @@ def test_github_login_redirect_sets_cookies_and_redirects(client) -> None:
 
     assert response.status_code == 303
     assert "https://github.com/login/oauth/authorize" in response.headers["location"]
-    assert "github_oauth_state=" in response.headers["set-cookie"]
+    assert "__session=" in response.headers["set-cookie"]
     parsed = urlparse(response.headers["location"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
     assert redirect_uri == "https://devforge-dev-nktebahhoq-an.a.run.app/auth/github/callback"
 
 
 def test_github_callback_redirect_rejects_state_mismatch(client) -> None:
-    client.cookies.set("github_oauth_state", "expected-state")
-    client.cookies.set("github_oauth_redirect", "http://localhost:5173/index.html")
+    client.cookies.set(
+        "__session",
+        json.dumps({"state": "expected-state", "redirect": "http://localhost:5173/index.html"}),
+    )
 
     with patch("httpx.AsyncClient") as mock_async_client:
         response = client.get(
@@ -337,8 +340,10 @@ def test_github_callback_redirect_rejects_state_mismatch(client) -> None:
 
 
 def test_github_callback_redirect_sets_auth_cookie(client) -> None:
-    client.cookies.set("github_oauth_state", "expected-state")
-    client.cookies.set("github_oauth_redirect", "http://localhost:5173/index.html")
+    client.cookies.set(
+        "__session",
+        json.dumps({"state": "expected-state", "redirect": "http://localhost:5173/index.html"}),
+    )
 
     token_response = MagicMock()
     token_response.json.return_value = {"access_token": "github-access-token"}
@@ -374,7 +379,7 @@ def test_begin_github_oauth_state_cookie_is_httponly(client) -> None:
     assert response.status_code == 200
     # Set-Cookie ヘッダーに HttpOnly が含まれていることを確認する
     set_cookie_header = response.headers.get("set-cookie", "")
-    assert "github_oauth_state=" in set_cookie_header
+    assert "__session=" in set_cookie_header
     assert "httponly" in set_cookie_header.lower()
 
 
@@ -387,7 +392,7 @@ def test_begin_github_oauth_state_cookie_has_samesite(client) -> None:
 
     assert response.status_code == 200
     set_cookie_header = response.headers.get("set-cookie", "")
-    assert "github_oauth_state=" in set_cookie_header
+    assert "__session=" in set_cookie_header
     assert "samesite=" in set_cookie_header.lower()
 
 


### PR DESCRIPTION
## 概要

dev 環境の GitHub OAuth ログインで、callback 時に `?github_error=OAuth+state+の検証に失敗しました` が発生し認証が完了しない問題を修正する。

**原因**: Firebase Hosting は `__session` という名前の Cookie のみ Cloud Run にプロキシし、それ以外の Cookie は CDN 層で除去される。OAuth 開始時に発行していた `github_oauth_state` / `github_oauth_redirect` の2つの Cookie が callback 時に Cloud Run に届かず、state 検証が必ず失敗していた。

デバッグログで確認済み:
```
callback cookies: {}
callback state_param: NTM7oxDET_kA73kmmJ9k9rPmVAC6P6v3327iD6RBmTI
```

**対応**: 2つの Cookie を `__session` 1つの JSON Cookie に統合する。

```
変更前:
  github_oauth_state=BVJ7aD...
  github_oauth_redirect=https://devforge-dev-20260311.web.app/

変更後:
  __session={"state":"BVJ7aD...","redirect":"https://devforge-dev-20260311.web.app/"}
```

## 変更内容

- `backend/app/routers/auth/token_manager.py`
  - `GITHUB_OAUTH_SESSION_COOKIE = "__session"` を追加
  - `set_github_oauth_session` / `get_github_oauth_session` / `clear_github_oauth_session` を追加（state と redirect を JSON で1つの Cookie に集約）
  - 既存の `GITHUB_OAUTH_STATE_COOKIE` / `GITHUB_OAUTH_REDIRECT_COOKIE` / `clear_github_oauth_cookies` は影響最小化のため残置
- `backend/app/routers/auth/oauth_flow.py`
  - `begin_github_oauth` 内で `set_github_oauth_session` を呼ぶように変更（`set_cookie` 2回 → 1回）
- `backend/app/routers/auth/endpoints.py`
  - GET / POST 両 callback で `get_github_oauth_session` から state / redirect を取り出す方式に変更
  - `clear_github_oauth_cookies` → `clear_github_oauth_session` に置換
  - 一時追加していた DEBUG ログ3行を削除
- `backend/tests/test_auth.py`
  - Cookie アサーション (`github_oauth_state=` → `__session=`) を更新
  - callback テストの Cookie セットを `__session` の JSON 形式に変更

## 関連 Issue

なし（dev 環境での障害対応）

## 確認事項

- [x] `cd backend && .venv/bin/python -m ruff check app tests alembic_migrations` がパス
- [x] `cd backend && .venv/bin/python -m pytest -q tests` がパス（388 passed）
- [ ] CI が通ること
- [ ] dev デプロイ後、GitHub OAuth ログインが完了することを実機で確認