### PR TITLE
[fix] GitHub OAuth callback を /github/callback に移動し Firebase rewrite を回避

### DIFF
--- a/backend/app/routers/auth/endpoints.py
+++ b/backend/app/routers/auth/endpoints.py
@@ -40,6 +40,11 @@ from .token_manager import (
     set_auth_cookies,
 )
 
+# GitHub OAuth Callback URL のパス
+# 旧: /auth/github/callback (Firebase Hosting の /auth/** rewrite に巻き込まれて Cookie が剥落するため不可)
+# 新: /github/callback (フロントの React ルートで受け取り、POST /auth/github/callback でトークン交換)
+GITHUB_CALLBACK_PATH = "/github/callback"
+
 router = APIRouter(prefix="/auth", tags=["auth"])
 logger = logging.getLogger(__name__)
 
@@ -142,13 +147,15 @@ def me(request: Request, current_user=Depends(get_current_user)) -> TokenRespons
 @limiter.limit("10/minute")
 def github_login_url(
     request: Request,
-    response: Response,
     return_to: str | None = None,
 ) -> dict[str, str]:
-    """GitHub OAuth 認可 URL を返す。"""
+    """GitHub OAuth 認可 URL と state を返す。
+
+    state はフロントが sessionStorage に保持し、コールバック時に CSRF 検証する。
+    """
     frontend_url = resolve_frontend_url_from_request(request, return_to)
-    authorization_url = begin_github_oauth(request, response, frontend_url)
-    return {"authorization_url": authorization_url}
+    authorization_url, state = begin_github_oauth(request, frontend_url)
+    return {"authorization_url": authorization_url, "state": state}
 
 
 @router.get("/github/login")
@@ -159,10 +166,8 @@ def github_login(
 ) -> RedirectResponse:
     """GitHub OAuth 認可 URL へリダイレクトする。"""
     frontend_url = resolve_frontend_url_from_request(request, return_to)
-    redirect = RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
-    redirect_url = begin_github_oauth(request, redirect, frontend_url)
-    redirect.headers["location"] = redirect_url
-    return redirect
+    authorization_url, _state = begin_github_oauth(request, frontend_url)
+    return RedirectResponse(url=authorization_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.get("/github/callback")
@@ -218,12 +223,13 @@ async def github_callback(
     payload: GitHubCallbackRequest,
     db: Session = Depends(get_db),
 ) -> TokenResponse:
-    """GitHub OAuth コードを受け取り、認証 Cookie を発行する。"""
-    stored_state, _ = get_github_oauth_session(request)
-    validate_github_oauth_state(stored_state, payload.state)
+    """GitHub OAuth コードを受け取り、認証 Cookie を発行する。
+
+    state はフロントの sessionStorage で検証済みのためサーバー側では再検証しない。
+    redirect_uri は GitHub OAuth App の登録値 (`/github/callback`) と一致させる必要がある。
+    """
     callback_base = get_callback_base_url() or build_external_base_url(request)
-    redirect_uri = f"{callback_base}/auth/github/callback"
+    redirect_uri = f"{callback_base}{GITHUB_CALLBACK_PATH}"
     token_response = await authenticate_github_user(db, payload.code, redirect_uri)
     set_auth_cookies(response, token_response.username, db)
-    clear_github_oauth_session(response)
     return token_response

--- a/backend/app/routers/auth/oauth_flow.py
+++ b/backend/app/routers/auth/oauth_flow.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from fastapi import HTTPException, Request, Response, status
+from fastapi import HTTPException, Request, status
 
 from ...core.errors import ErrorCode, raise_app_error
 from ...core.messages import get_error
@@ -14,7 +14,6 @@ from ...core.settings import get_callback_base_url, get_cors_origins, get_github
 from .token_manager import (
     GITHUB_OAUTH_REDIRECT_COOKIE,
     GITHUB_OAUTH_STATE_COOKIE,
-    set_github_oauth_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -200,15 +199,25 @@ def build_github_authorization_url(
 
 def begin_github_oauth(
     request: Request,
-    response: Response,
     frontend_url: str,
-) -> str:
+) -> tuple[str, str]:
     """
     GitHub OAuth フローを開始する。
 
-    state と redirect URL を Cookie に保存し、GitHub 認可 URL を返す。
+    state は Cookie に保存せず、呼び出し側でフロント (sessionStorage) に渡す。
+    Firebase Hosting の `/auth/**` rewrite を回避するため、コールバック URL は
+    `/github/callback` (フロントの React ルート) に揃える。
+
     GITHUB_CLIENT_ID が未設定の場合は503を発生させる。
+
+    Args:
+        frontend_url: 認証完了後の遷移先（現状は `state` 検証のフロント実装で利用）
+
+    Returns:
+        (authorization_url, state) のタプル
     """
+    # frontend_url は将来の拡張用に受け取る（現状は使用しない）
+    del frontend_url
     client_id = get_github_client_id()
     if not client_id:
         raise_app_error(
@@ -219,13 +228,12 @@ def begin_github_oauth(
         )
 
     callback_base = get_callback_base_url() or build_external_base_url(request)
-    redirect_uri = f"{callback_base}/auth/github/callback"
+    redirect_uri = f"{callback_base}/github/callback"
     state = secrets.token_urlsafe(32)
 
-    set_github_oauth_session(response, state, frontend_url)
-
-    return build_github_authorization_url(
+    authorization_url = build_github_authorization_url(
         client_id=client_id,
         redirect_uri=redirect_uri,
         state=state,
     )
+    return authorization_url, state

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -256,15 +256,24 @@ def test_get_request_skips_csrf_check(client) -> None:
 # ── GitHub OAuth ──────────────────────────────────────────────────
 
 
-def test_github_login_url_sets_state_cookie(client) -> None:
+def test_github_login_url_returns_state(client) -> None:
+    """login-url エンドポイントが authorization_url と state を JSON で返すことを確認する。"""
     response = client.get(
         "/auth/github/login-url",
         headers={"Origin": "http://localhost:5173"},
     )
 
     assert response.status_code == 200
-    assert "https://github.com/login/oauth/authorize" in response.json()["authorization_url"]
-    assert "__session=" in response.headers["set-cookie"]
+    data = response.json()
+    assert "https://github.com/login/oauth/authorize" in data["authorization_url"]
+    # state はフロントの sessionStorage に保存して CSRF 検証する
+    assert isinstance(data["state"], str)
+    assert len(data["state"]) > 0
+    # /auth/** rewrite を回避するため redirect_uri は /github/callback でなければならない
+    parsed = urlparse(data["authorization_url"])
+    redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
+    assert redirect_uri.endswith("/github/callback")
+    assert "/auth/github/callback" not in redirect_uri
 
 
 def test_github_login_url_uses_forwarded_https_scheme(client) -> None:
@@ -280,7 +289,7 @@ def test_github_login_url_uses_forwarded_https_scheme(client) -> None:
     assert response.status_code == 200
     parsed = urlparse(response.json()["authorization_url"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
-    assert redirect_uri == "https://devforge-dev-nktebahhoq-an.a.run.app/auth/github/callback"
+    assert redirect_uri == "https://devforge-dev-nktebahhoq-an.a.run.app/github/callback"
 
 
 def test_github_login_url_uses_callback_base_url_when_set(client) -> None:
@@ -298,10 +307,11 @@ def test_github_login_url_uses_callback_base_url_when_set(client) -> None:
     assert response.status_code == 200
     parsed = urlparse(response.json()["authorization_url"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
-    assert redirect_uri == "https://devforge-dev-20260311.web.app/auth/github/callback"
+    assert redirect_uri == "https://devforge-dev-20260311.web.app/github/callback"
 
 
-def test_github_login_redirect_sets_cookies_and_redirects(client) -> None:
+def test_github_login_redirect_to_github(client) -> None:
+    """GET /auth/github/login が GitHub の認可 URL に 303 リダイレクトすることを確認する。"""
     response = client.get(
         "/auth/github/login",
         params={"return_to": "http://localhost:5173/index.html"},
@@ -314,10 +324,9 @@ def test_github_login_redirect_sets_cookies_and_redirects(client) -> None:
 
     assert response.status_code == 303
     assert "https://github.com/login/oauth/authorize" in response.headers["location"]
-    assert "__session=" in response.headers["set-cookie"]
     parsed = urlparse(response.headers["location"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
-    assert redirect_uri == "https://devforge-dev-nktebahhoq-an.a.run.app/auth/github/callback"
+    assert redirect_uri == "https://devforge-dev-nktebahhoq-an.a.run.app/github/callback"
 
 
 def test_github_callback_redirect_rejects_state_mismatch(client) -> None:
@@ -369,31 +378,42 @@ def test_github_callback_redirect_sets_auth_cookie(client) -> None:
     assert "access_token=" in response.headers["set-cookie"]
 
 
-def test_begin_github_oauth_state_cookie_is_httponly(client) -> None:
-    """begin_github_oauth が設定する state Cookie が HttpOnly であることを確認する。"""
-    response = client.get(
-        "/auth/github/login-url",
-        headers={"Origin": "http://localhost:5173"},
-    )
+def test_github_callback_post_does_not_require_cookie(client) -> None:
+    """POST /auth/github/callback は Cookie の state を検証せずトークン交換に進むことを確認する。
+
+    state はフロントの sessionStorage で検証済みのためサーバー側では Cookie を見ない。
+    """
+    token_response = MagicMock()
+    token_response.json.return_value = {"access_token": "github-access-token"}
+    user_response = MagicMock()
+    user_response.json.return_value = {"id": 67890, "login": "octo-post"}
+
+    client.cookies.clear()  # Cookie が無くても通ることを確認する
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post.return_value = token_response
+        mock_http.get.return_value = user_response
+        mock_cls.return_value = mock_http
+
+        response = client.post(
+            "/auth/github/callback",
+            json={"code": "test-code", "state": "any-state-from-frontend"},
+            headers={
+                "Host": "devforge-dev-nktebahhoq-an.a.run.app",
+                "X-Forwarded-Proto": "https",
+            },
+        )
 
     assert response.status_code == 200
-    # Set-Cookie ヘッダーに HttpOnly が含まれていることを確認する
-    set_cookie_header = response.headers.get("set-cookie", "")
-    assert "__session=" in set_cookie_header
-    assert "httponly" in set_cookie_header.lower()
-
-
-def test_begin_github_oauth_state_cookie_has_samesite(client) -> None:
-    """begin_github_oauth が設定する state Cookie に SameSite 属性が含まれることを確認する。"""
-    response = client.get(
-        "/auth/github/login-url",
-        headers={"Origin": "http://localhost:5173"},
-    )
-
-    assert response.status_code == 200
-    set_cookie_header = response.headers.get("set-cookie", "")
-    assert "__session=" in set_cookie_header
-    assert "samesite=" in set_cookie_header.lower()
+    assert response.json()["username"] == "github:octo-post"
+    assert "access_token=" in response.headers["set-cookie"]
+    # GitHub への redirect_uri も /github/callback でトークン交換していることを確認する
+    posted_kwargs = mock_http.post.call_args.kwargs
+    assert posted_kwargs["json"]["redirect_uri"].endswith("/github/callback")
+    assert "/auth/github/callback" not in posted_kwargs["json"]["redirect_uri"]
 
 
 # ── 不正アクセス追跡: 認証失敗ログ ────────────────────────────────

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -54,6 +54,7 @@ test.describe("未認証ユーザー", () => {
         contentType: "application/json",
         body: JSON.stringify({
           authorization_url: "http://localhost:5173/mock-github-oauth",
+          state: "mock-state",
         }),
       });
     });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -22,15 +22,21 @@ export async function handleGitHubCallback(code: string, state: string): Promise
   });
 }
 
-/** Firebase Hosting proxy 経由では 303 の Set-Cookie が除去されるため、
- *  200 JSON エンドポイントを fetch して state cookie をセットしてから GitHub へ遷移する。 */
+/** sessionStorage の key。CSRF 検証用に GitHub OAuth state を保持する。 */
+export const GITHUB_OAUTH_STATE_STORAGE_KEY = "github_oauth_state";
+
+/** Firebase Hosting は __session 以外の Cookie を Cloud Run に転送せず、
+ *  さらに /auth/** rewrite の影響でフロントの React ルートにも到達できないため、
+ *  state は sessionStorage で管理し、コールバック URL は /github/callback に揃える。 */
 export async function initiateGitHubLogin(returnTo: string): Promise<void> {
   const params = new URLSearchParams({ return_to: returnTo });
   const response = await fetch(`${API_BASE_URL}/auth/github/login-url?${params.toString()}`, {
     credentials: "include",
   });
   if (!response.ok) throw new Error("GitHub OAuth の開始に失敗しました");
-  const data = (await response.json()) as { authorization_url: string };
+  const data = (await response.json()) as { authorization_url: string; state: string };
+  // CSRF 検証用に state を sessionStorage へ保存する（コールバックで照合）
+  sessionStorage.setItem(GITHUB_OAUTH_STATE_STORAGE_KEY, data.state);
   window.location.assign(data.authorization_url);
 }
 

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { handleGitHubCallback } from "../api/auth";
+import { GITHUB_OAUTH_STATE_STORAGE_KEY, handleGitHubCallback } from "../api/auth";
 import shared from "../styles/shared.module.css";
 
 type Props = {
@@ -19,16 +19,27 @@ export default function GitHubCallbackPage({ onLoginSuccess }: Props) {
 
     const code = searchParams.get("code");
     const state = searchParams.get("state");
+    const storedState = sessionStorage.getItem(GITHUB_OAUTH_STATE_STORAGE_KEY);
 
     if (!code || !state) {
       navigate("/login?github_error=invalid_callback", { replace: true });
       return;
     }
 
+    // CSRF 検証: sessionStorage の state と URL の state を照合する
+    if (!storedState || storedState !== state) {
+      sessionStorage.removeItem(GITHUB_OAUTH_STATE_STORAGE_KEY);
+      navigate("/login?github_error=state_mismatch", { replace: true });
+      return;
+    }
+
+    // 使用済み state を削除（リプレイ攻撃防止）
+    sessionStorage.removeItem(GITHUB_OAUTH_STATE_STORAGE_KEY);
+
     handleGitHubCallback(code, state)
       .then((user) => {
         onLoginSuccess(user);
-        navigate("/", { replace: true });
+        navigate("/career", { replace: true });
       })
       .catch(() => {
         navigate("/login?github_error=authentication_failed", { replace: true });

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -60,8 +60,12 @@ export default function AppRoutes({
         </Route>
       </Route>
 
+      {/*
+        GitHub OAuth コールバック: Firebase Hosting の /auth/** rewrite に巻き込まれて
+        Cloud Run へ転送されないように、/github/callback で受け取る。
+      */}
       <Route
-        path="/auth/github/callback"
+        path="/github/callback"
         element={<GitHubCallbackPage onLoginSuccess={onLoginSuccess} />}
       />
 


### PR DESCRIPTION
## 概要

dev 環境で GitHub OAuth ログインが完了せず `?github_error=...` で `/login` に戻る問題を修正する。

**構造的原因**: `firebase.json` の `/auth/**` rewrite が `/auth/github/callback` にも適用されるため、GitHub からのリダイレクトが Firebase 経由で Cloud Run の GET エンドポイントへ転送される。`__session` 以外の Cookie は CDN 層で剥落するため、state 検証が必ず失敗する。フロントの `GitHubCallbackPage` には一度も到達できていなかった。

**対応**: コールバック URL を `/auth/**` に巻き込まれない `/github/callback` に変更し、フロントの React ページで `code` / `state` を受け取る。state は sessionStorage で CSRF 検証する。

```
新しいフロー:
  1. GET /auth/github/login-url → { authorization_url, state } を返す
  2. フロントが state を sessionStorage に保存
  3. GitHub → web.app/github/callback?code=...&state=...
  4. Firebase → index.html → GitHubCallbackPage（React）
  5. sessionStorage の state と URL の state を比較・検証
  6. POST /auth/github/callback { code, state } → HttpOnly Cookie セット成功
```

## 変更内容

### backend

- `backend/app/routers/auth/oauth_flow.py`
  - `begin_github_oauth(request, frontend_url) -> tuple[str, str]` に変更し、state を Cookie に保存せず `(authorization_url, state)` を返すようにする
  - `redirect_uri` を `/github/callback` に変更
- `backend/app/routers/auth/endpoints.py`
  - `GET /auth/github/login-url`: レスポンスに `state` を含める
  - `GET /auth/github/login`: 新しい `begin_github_oauth` の戻り値に追従
  - `POST /auth/github/callback`: Cookie ベースの state 検証を撤去（フロントの sessionStorage で検証済み）／`redirect_uri` を `/github/callback` に変更
  - `GET /auth/github/callback` (legacy): stg/prod の OAuth App 設定が旧 URL のままでも壊れないように削除せず据え置き

### frontend

- `frontend/src/api/auth.ts`
  - `initiateGitHubLogin`: `state` を `sessionStorage["github_oauth_state"]` に保存してから GitHub へ遷移
  - 共通定数 `GITHUB_OAUTH_STATE_STORAGE_KEY` を export
- `frontend/src/pages/GitHubCallbackPage.tsx`
  - sessionStorage の state と URL の state を照合（不一致なら `?github_error=state_mismatch` で `/login` に戻す）
  - 使用済み state は即削除（リプレイ防止）
  - 認証成功時の遷移先を `/` → `/career` に修正
- `frontend/src/router/routes.tsx`
  - `/auth/github/callback` → `/github/callback` にルートを移動
- `frontend/e2e/auth.spec.ts`
  - login-url のモックレスポンスに `state` を追加

### tests

- `backend/tests/test_auth.py`
  - `test_github_login_url_returns_state` を追加（JSON に state が返ること、redirect_uri が `/github/callback` であること）
  - `test_github_login_url_uses_*` の `redirect_uri` を `/github/callback` に更新
  - `test_github_login_redirect_to_github` に改名（cookie アサーション削除、redirect_uri 更新）
  - `test_github_callback_post_does_not_require_cookie` を追加（POST が Cookie 無しで通り、`/github/callback` でトークン交換すること）
  - 旧 `test_begin_github_oauth_state_cookie_*` 2件を削除（state は Cookie ではなく sessionStorage に移行したため）

## デプロイ手順（重要）

> **必ず GitHub OAuth App の callback URL を変更してからデプロイすること。**
> 不一致の状態でデプロイすると認証が完全に壊れる。

1. GitHub → Settings → Developer settings → OAuth Apps → DevForge Dev
   - `Authorization callback URL` を以下に変更:
     - 旧: `https://devforge-dev-20260311.web.app/auth/github/callback`
     - 新: `https://devforge-dev-20260311.web.app/github/callback`
2. この PR をマージ (deploy-backend / deploy-frontend が走る)
3. 動作確認:
   - DevTools → Application → sessionStorage に `github_oauth_state` が保存されること
   - GitHub 認証後 `/github/callback` → `/career` に遷移すること
   - DevTools → Application → Cookies に `access_token` がセットされていること

## 関連 Issue

なし（dev 環境での障害対応の続編、#216 で残った問題の構造的修正）

## 確認事項

- [x] `cd backend && .venv/bin/python -m ruff check app tests alembic_migrations` パス
- [x] `cd backend && .venv/bin/python -m pytest -q tests` パス（387 passed）
- [x] `cd frontend && npm run lint` パス
- [x] `cd frontend && npm run test:vitest` パス（74 passed）
- [x] `cd frontend && npm run build` パス
- [x] `cd frontend && npm run test:e2e` パス（13 passed）
- [ ] CI が通ること
- [ ] **マージ前に GitHub OAuth App の callback URL を変更**
- [ ] dev デプロイ後、GitHub OAuth ログインが完了することを実機で確認