### PR TITLE
# 職務経歴書: 非IT経歴・休暇・資本金単位 + GitHubコントリビューション可視化

### DIFF
--- a/backend/alembic_migrations/versions/0039_add_capital_unit.py
+++ b/backend/alembic_migrations/versions/0039_add_capital_unit.py
@@ -1,0 +1,41 @@
+"""resume_experiences に capital_unit カラムを追加する
+
+資本金の単位（万円 / 百万円 / 千万円 / 億円）を在籍企業ごとに選択できるようにする。
+従来は表示時に「千万円」固定だったため、既存行の後方互換として server_default を
+「千万円」にする。
+
+libSQL (SQLite 互換) は ALTER COLUMN / DROP COLUMN を直接サポートしないため、
+downgrade の列削除は batch_alter_table（テーブル再作成）で行う。ADD COLUMN は
+SQLite が直接サポートするため upgrade は op.add_column をそのまま使う。
+
+Revision ID: 0039_add_capital_unit
+Revises: 0038_add_project_periods_table
+Create Date: 2026-05-29 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0039_add_capital_unit"
+down_revision: Union[str, None] = "0038_add_project_periods_table"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_experiences",
+        sa.Column(
+            "capital_unit",
+            sa.String(12),
+            nullable=False,
+            server_default="千万円",
+        ),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("resume_experiences") as batch_op:
+        batch_op.drop_column("capital_unit")

--- a/backend/alembic_migrations/versions/0040_add_resume_non_it_and_vacation.py
+++ b/backend/alembic_migrations/versions/0040_add_resume_non_it_and_vacation.py
@@ -1,0 +1,68 @@
+"""非IT経歴フラグ・詳細と休暇エントリのカラムを追加する
+
+- resume_experiences に is_it_company（IT企業かどうか）と description（非IT時の詳細）を追加。
+  既存行は IT 企業前提だったため is_it_company の server_default を True(1) にする。
+- resume_clients に is_vacation（休暇エントリか）と vacation_* 期間/詳細を追加。
+  既存行は通常の取引先のため is_vacation の server_default を False(0) にする。
+
+libSQL (SQLite 互換) は ADD COLUMN を直接サポートするため upgrade は op.add_column を
+そのまま使う。downgrade の列削除は ALTER/DROP COLUMN 非対応のため batch_alter_table
+（テーブル再作成）で行う。
+
+Revision ID: 0040_add_resume_non_it_and_vacation
+Revises: 0039_add_capital_unit
+Create Date: 2026-05-29 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0040_add_resume_non_it_and_vacation"
+down_revision: Union[str, None] = "0039_add_capital_unit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_experiences",
+        sa.Column("is_it_company", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+    )
+    op.add_column(
+        "resume_experiences",
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "resume_clients",
+        sa.Column("is_vacation", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "resume_clients",
+        sa.Column("vacation_start_date", sa.Date(), nullable=True),
+    )
+    op.add_column(
+        "resume_clients",
+        sa.Column("vacation_end_date", sa.Date(), nullable=True),
+    )
+    op.add_column(
+        "resume_clients",
+        sa.Column("vacation_is_current", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "resume_clients",
+        sa.Column("vacation_description", sa.Text(), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("resume_clients") as batch_op:
+        batch_op.drop_column("vacation_description")
+        batch_op.drop_column("vacation_is_current")
+        batch_op.drop_column("vacation_end_date")
+        batch_op.drop_column("vacation_start_date")
+        batch_op.drop_column("is_vacation")
+    with op.batch_alter_table("resume_experiences") as batch_op:
+        batch_op.drop_column("description")
+        batch_op.drop_column("is_it_company")

--- a/backend/app/messages.json
+++ b/backend/app/messages.json
@@ -39,7 +39,8 @@
       "github_user_not_found": "GitHubユーザーが見つかりません: {username}",
       "profile_fetch_failed": "GitHubプロフィールの取得に失敗しました。しばらくしてから再度お試しください。",
       "no_link_cache": "連携データがありません。先にGitHub連携を実行してください。",
-      "not_retryable": "このタスクはリトライできない状態です（現在: {status}）。"
+      "not_retryable": "このタスクはリトライできない状態です（現在: {status}）。",
+      "contribution_fetch_failed": "コントリビューション情報の取得に失敗しました。スキル集計は表示されています。"
     },
     "validation": {
       "required_field": "{field}は必須です。",

--- a/backend/app/models/resume.py
+++ b/backend/app/models/resume.py
@@ -104,6 +104,12 @@ class ResumeExperience(Base):
     is_current: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     employee_count: Mapped[str] = mapped_column(String(60), nullable=False, default="")
     capital: Mapped[str] = mapped_column(String(120), nullable=False, default="")
+    # 資本金の単位（万円 / 百万円 / 千万円 / 億円）。既定は後方互換のため「千万円」。
+    capital_unit: Mapped[str] = mapped_column(String(12), nullable=False, default="千万円")
+    # IT 企業かどうか。False（非IT）の場合は取引先/プロジェクトを持たず description を使う。
+    is_it_company: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # 非IT企業の職務内容を記述する自由記述欄（見出し「詳細」）。
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     client_rows: Mapped[list["ResumeClient"]] = relationship(
         back_populates="experience",
         cascade="all, delete-orphan",
@@ -138,6 +144,16 @@ class ResumeClient(Base):
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     name: Mapped[str] = mapped_column(String(200), nullable=False, default="")
     has_client: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # 休暇エントリ。True のとき取引先ではなく在籍中の休暇を表し vacation_* を使う。
+    is_vacation: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    vacation_start_date_value: Mapped[date | None] = mapped_column(
+        "vacation_start_date", Date, nullable=True
+    )
+    vacation_end_date_value: Mapped[date | None] = mapped_column(
+        "vacation_end_date", Date, nullable=True
+    )
+    vacation_is_current: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    vacation_description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     project_rows: Mapped[list["ResumeProject"]] = relationship(
         back_populates="client",
         cascade="all, delete-orphan",
@@ -149,6 +165,15 @@ class ResumeClient(Base):
     def projects(self) -> list["ResumeProject"]:
         """プロジェクトを期間の降順でソートして返す。"""
         return sort_by_period_desc(list(self.project_rows))
+
+    @property
+    def vacation_start_date(self) -> str:
+        return format_year_month(self.vacation_start_date_value) or ""
+
+    @property
+    def vacation_end_date(self) -> str:
+        """DB の vacation_end_date が NULL（継続中）の場合は "" を返す。"""
+        return format_year_month(self.vacation_end_date_value) or ""
 
 
 class ResumeProject(Base):

--- a/backend/app/repositories/resume.py
+++ b/backend/app/repositories/resume.py
@@ -77,6 +77,9 @@ class ResumeRepository(SingleUserDocumentRepository):
             is_current=payload.get("is_current", False),
             employee_count=payload.get("employee_count", ""),
             capital=payload.get("capital", ""),
+            capital_unit=payload.get("capital_unit", "千万円"),
+            is_it_company=payload.get("is_it_company", True),
+            description=payload.get("description", ""),
             client_rows=[
                 self._build_client_row(client_index, client)
                 for client_index, client in enumerate(payload.get("clients", []))
@@ -86,10 +89,17 @@ class ResumeRepository(SingleUserDocumentRepository):
     def _build_client_row(self, index: int, payload: dict[str, object]) -> ResumeClient:
         projects = list(payload.get("projects", []))
         sorted_projects = sorted(projects, key=self._project_sort_key)
+        vacation_start = payload.get("vacation_start_date") or ""
+        vacation_end = payload.get("vacation_end_date") or ""
         return ResumeClient(
             sort_order=index,
             name=payload.get("name", ""),
             has_client=payload.get("has_client", True),
+            is_vacation=payload.get("is_vacation", False),
+            vacation_start_date_value=parse_year_month(vacation_start) if vacation_start else None,
+            vacation_end_date_value=parse_year_month(vacation_end) if vacation_end else None,
+            vacation_is_current=payload.get("vacation_is_current", False),
+            vacation_description=payload.get("vacation_description", ""),
             project_rows=[
                 self._build_project_row(project_index, project)
                 for project_index, project in enumerate(sorted_projects)

--- a/backend/app/schemas/github_link.py
+++ b/backend/app/schemas/github_link.py
@@ -15,6 +15,24 @@ class GitHubLinkRequest(BaseModel):
     )
 
 
+class ContributionDay(BaseModel):
+    """コントリビューションカレンダーの 1 日分。"""
+
+    date: str = Field(description="ISO 8601 形式の日付 (YYYY-MM-DD)")
+    count: int = Field(description="その日のコントリビューション数")
+    level: int = Field(description="GitHub の濃淡レベル (0–4)")
+
+
+class ContributionCalendar(BaseModel):
+    """直近1年のコントリビューションカレンダー（GitHub の緑の四角）。"""
+
+    total_contributions: int = Field(description="期間内のコントリビューション総数")
+    weeks: list[list[ContributionDay]] = Field(
+        default_factory=list,
+        description="週ごとの日配列（列=週、各週は最大7日）",
+    )
+
+
 class GitHubLinkResponse(BaseModel):
     username: str
     repos_analyzed: int
@@ -35,6 +53,10 @@ class GitHubLinkResponse(BaseModel):
     detected_infras: Dict[str, int] = Field(
         default_factory=dict,
         description="ルートファイルから検出したインフラツール名 → 使用リポジトリ数",
+    )
+    contribution_calendar: Optional[ContributionCalendar] = Field(
+        default=None,
+        description="直近1年のコントリビューションカレンダー（取得失敗時は None）",
     )
 
 

--- a/backend/app/schemas/resume.py
+++ b/backend/app/schemas/resume.py
@@ -5,6 +5,11 @@ FE 同期: 本モジュールの各 Item / レスポンス型は ``frontend/src/
 ``CareerProject`` / ``CareerClient`` / ``CareerExperience`` 等）と対になる DTO。
 言語境界のため codegen 未導入の手動同期で運用している（エラーコードの errors.py と同方針）。
 フィールドを増減・rename する場合は対応する FE type も同時に更新すること。
+
+非IT経歴: ``Experience.is_it_company=False`` のとき取引先/プロジェクトを持たず
+``Experience.description``（詳細）のみ使う。
+休暇: ``Client.is_vacation=True`` のとき取引先ではなく在籍中の休暇を表し、
+``Client.vacation_*``（期間・詳細）を使う。
 """
 
 from datetime import datetime
@@ -125,13 +130,44 @@ class Project(BaseModel):
         return data
 
 class Client(BaseModel):
-    """ユーザ（常駐先/クライアント企業）。"""
+    """ユーザ（常駐先/クライアント企業）。
+
+    ``is_vacation=True`` の場合は取引先ではなく在籍中の休暇（育児/介護/留学等）を表し、
+    name / projects の代わりに ``vacation_*`` 期間と詳細を保持する。
+    """
 
     name: str = Field(max_length=200, default="")
     has_client: bool = True
     projects: list[Project] = Field(default_factory=list)
+    # 休暇エントリ。True のとき vacation_* を期間・詳細として扱い projects は無視する。
+    is_vacation: bool = False
+    vacation_start_date: str = Field(default="", max_length=30)
+    # 継続中（vacation_is_current=True）の場合は "" を渡す契約。
+    vacation_end_date: str = Field(default="", max_length=30)
+    vacation_is_current: bool = False
+    vacation_description: str = Field(max_length=4500, default="")
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def validate_vacation_dates(self) -> "Client":
+        """休暇の期間を検証する（Experience.validate_dates と同じ契約）。
+
+        休暇でない取引先は検証対象外。開始年月は必須、継続中なら end を ""
+        に正規化し、それ以外は終了年月必須かつ end >= start を要求する。
+        """
+        if not self.is_vacation:
+            return self
+        if not self.vacation_start_date.strip():
+            raise ValueError(get_error("validation.start_date_required"))
+        if self.vacation_is_current:
+            self.vacation_end_date = ""
+            return self
+        if not self.vacation_end_date.strip():
+            raise ValueError(get_error("validation.end_date_required"))
+        if self.vacation_end_date < self.vacation_start_date:
+            raise ValueError(get_error("validation.date_range_invalid"))
+        return self
 
 
 class Experience(BaseModel):
@@ -145,6 +181,12 @@ class Experience(BaseModel):
     is_current: bool = False
     employee_count: str = Field(max_length=60, default="")
     capital: str = Field(max_length=120, default="")
+    # 資本金の単位。既定は後方互換のため「千万円」。FE の CapitalUnit と対の DTO。
+    capital_unit: Literal["万円", "百万円", "千万円", "億円"] = Field(default="千万円")
+    # IT 企業かどうか。False（非IT）の場合は取引先/プロジェクトを持たず description を使う。
+    is_it_company: bool = True
+    # 非IT企業の職務内容を記述する自由記述欄（見出し「詳細」）。business_description=事業内容 とは別。
+    description: str = Field(max_length=4500, default="")
     clients: list[Client] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/intelligence/github/contributions.py
+++ b/backend/app/services/intelligence/github/contributions.py
@@ -1,0 +1,146 @@
+"""
+GitHub GraphQL API でコントリビューションカレンダーを取得するモジュール。
+
+REST では取得できない「緑の四角」カレンダー（contributionsCollection）を
+GraphQL から取得する。`read:user` スコープのトークンで公開プロフィールの
+コントリビューション情報を読み取れる。
+
+このモジュールは連携パイプラインの**補助処理**であり、取得失敗時は
+``logger.warning`` を残して ``None`` を返す（主処理のリポジトリ解析を巻き添えにしない）。
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from ....schemas.github_link import ContributionCalendar, ContributionDay
+from .api_client import GITHUB_API
+
+logger = logging.getLogger(__name__)
+
+_GRAPHQL_ENDPOINT = f"{GITHUB_API}/graphql"
+
+# GraphQL の contributionLevel enum を 0–4 の整数に正規化する対応表。
+_LEVEL_MAP = {
+    "NONE": 0,
+    "FIRST_QUARTILE": 1,
+    "SECOND_QUARTILE": 2,
+    "THIRD_QUARTILE": 3,
+    "FOURTH_QUARTILE": 4,
+}
+
+_CONTRIBUTION_QUERY = """
+query($login: String!) {
+  user(login: $login) {
+    contributionsCollection {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            date
+            contributionCount
+            contributionLevel
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+async def fetch_contribution_calendar(
+    username: str,
+    token: str,
+) -> Optional[ContributionCalendar]:
+    """GitHub のコントリビューションカレンダー（直近1年）を取得する。
+
+    取得に失敗した場合（認証エラー・レート制限・ネットワーク障害・GraphQL エラー等）は
+    ``logger.warning`` を残して ``None`` を返す。連携自体は継続させる補助処理のため、
+    例外を送出しない。
+
+    Args:
+        username: 対象 GitHub ユーザー名。
+        token: 認証用アクセストークン（復号済み）。
+
+    Returns:
+        ``ContributionCalendar`` または取得失敗時は ``None``。
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                _GRAPHQL_ENDPOINT,
+                headers=headers,
+                json={
+                    "query": _CONTRIBUTION_QUERY,
+                    "variables": {"login": username},
+                },
+            )
+    except (httpx.TimeoutException, httpx.ConnectError, httpx.HTTPError) as exc:
+        logger.warning(
+            "コントリビューション取得でネットワーク障害 (username=%s): %s",
+            username,
+            exc,
+        )
+        return None
+
+    if resp.status_code != 200:
+        logger.warning(
+            "コントリビューション取得が HTTP %s で失敗 (username=%s)",
+            resp.status_code,
+            username,
+        )
+        return None
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        logger.warning("コントリビューション応答の JSON 解析に失敗 (username=%s)", username)
+        return None
+
+    if payload.get("errors"):
+        logger.warning(
+            "コントリビューション取得で GraphQL エラー (username=%s): %s",
+            username,
+            payload["errors"],
+        )
+        return None
+
+    user = (payload.get("data") or {}).get("user")
+    if not user:
+        logger.warning("コントリビューション対象ユーザーが見つからない (username=%s)", username)
+        return None
+
+    calendar_raw = (user.get("contributionsCollection") or {}).get(
+        "contributionCalendar"
+    )
+    if not calendar_raw:
+        logger.warning("コントリビューションカレンダーが空 (username=%s)", username)
+        return None
+
+    return _parse_calendar(calendar_raw)
+
+
+def _parse_calendar(calendar_raw: dict) -> ContributionCalendar:
+    """GraphQL の contributionCalendar を ``ContributionCalendar`` に変換する。"""
+    weeks: list[list[ContributionDay]] = []
+    for week in calendar_raw.get("weeks", []):
+        days = [
+            ContributionDay(
+                date=day["date"],
+                count=day.get("contributionCount", 0),
+                level=_LEVEL_MAP.get(day.get("contributionLevel", "NONE"), 0),
+            )
+            for day in week.get("contributionDays", [])
+        ]
+        weeks.append(days)
+
+    return ContributionCalendar(
+        total_contributions=calendar_raw.get("totalContributions", 0),
+        weeks=weeks,
+    )

--- a/backend/app/services/intelligence/github_link_service.py
+++ b/backend/app/services/intelligence/github_link_service.py
@@ -12,10 +12,12 @@ from datetime import datetime, timezone
 
 from ...core.encryption import decrypt_field
 from ...core.logging_utils import get_logger
+from ...core.messages import get_error
 from ...models import GitHubLinkCache
 from ..progress_service import set_progress
 from ..tasks.exceptions import NonRetryableError
 from ..tasks.handlers.base import SessionFactory
+from .github.contributions import fetch_contribution_calendar
 from .github_collector import GitHubUserNotFoundError, collect_repos
 from .pipeline import aggregate_intelligence
 from .response_mapper import map_pipeline_result
@@ -94,11 +96,17 @@ async def run_github_link(session_factory: SessionFactory, payload: dict) -> Non
                 db.commit()
         raise exc
 
+    # コントリビューションカレンダー取得（補助処理: 失敗しても連携は継続）
+    calendar = None
+    if token:
+        calendar = await fetch_contribution_calendar(payload["github_username"], token)
+
     # ステップ 3: スキル抽出（集計関数で一括処理）
     await set_progress(task_id, 3, _TOTAL_STEPS, "スキル集計中...")
     result = aggregate_intelligence(payload["github_username"], repos)
 
     response = map_pipeline_result(result)
+    response.contribution_calendar = calendar
     result_dict = response.model_dump()
 
     # ── フェーズC: 結果書き戻し（新セッション）─────────────────────────────
@@ -115,7 +123,10 @@ async def run_github_link(session_factory: SessionFactory, payload: dict) -> Non
         cache.result = result_dict
         cache.status = "completed"
         cache.error_message = None
-        cache.warning_message = None
+        # コントリビューション取得失敗は連携自体を失敗させず警告として残す
+        cache.warning_message = (
+            get_error("github_link.contribution_fetch_failed") if calendar is None else None
+        )
         cache.completed_at = _now()
         db.commit()
 

--- a/backend/app/services/markdown/generators/resume_generator.py
+++ b/backend/app/services/markdown/generators/resume_generator.py
@@ -59,12 +59,35 @@ def build_resume_markdown(payload: dict[str, Any]) -> str:
                 lines.append(field_line("従業員数", f"{emp}名"))
             cap = _a(exp, "capital")
             if cap:
-                lines.append(field_line("資本金", f"{cap}千万円"))
+                cap_unit = _a(exp, "capital_unit", "千万円")
+                lines.append(field_line("資本金", f"{cap}{cap_unit}"))
             lines.append("")
+
+            if not _a(exp, "is_it_company", True):
+                # 非IT企業: 取引先/プロジェクトの代わりに詳細を出力
+                detail = _a(exp, "description")
+                if detail:
+                    lines.append(field_line("詳細", detail))
+                    lines.append("")
+                continue
 
             # clients → projects（後方互換含む正規化は shared に集約）
             clients = normalize_clients(exp)
             for client in clients:
+                if _a(client, "is_vacation", False):
+                    period = format_period(
+                        _a(client, "vacation_start_date"),
+                        _a(client, "vacation_end_date", ""),
+                        _a(client, "vacation_is_current", False),
+                    )
+                    lines.append("#### 休暇")
+                    lines.append("")
+                    lines.append(field_line("期間", period))
+                    vacation_detail = _a(client, "vacation_description")
+                    if vacation_detail:
+                        lines.append(field_line("詳細", vacation_detail))
+                    lines.append("")
+                    continue
                 client_name = _a(client, "name")
                 if client_name:
                     lines.append(f"#### {client_name}")

--- a/backend/app/services/pdf/generators/resume_generator.py
+++ b/backend/app/services/pdf/generators/resume_generator.py
@@ -128,6 +128,24 @@ def _build_project_html(project) -> str:
     )
 
 
+def _build_vacation_html(client) -> str:
+    """休暇エントリ1件分のHTMLを組み立てる（期間 + 詳細）。"""
+    period = _format_period(
+        _a(client, "vacation_start_date"),
+        _a(client, "vacation_end_date", ""),
+        _a(client, "vacation_is_current", False),
+    )
+    header = f"休暇　{_esc(period)}" if period else "休暇"
+    description = _a(client, "vacation_description")
+    body = _md(description) if description else "-"
+    return (
+        f'<div class="vacation">'
+        f'<div class="vacation-header">{header}</div>'
+        f'<div class="vacation-body">{body}</div>'
+        f"</div>"
+    )
+
+
 def _build_html(resume: dict) -> str:
     """職務経歴書データからHTML文字列を組み立てる"""
     parts: list[str] = []
@@ -171,7 +189,8 @@ def _build_html(resume: dict) -> str:
             )
             capital_raw = _a(exp, "capital")
             emp_raw = _a(exp, "employee_count")
-            capital = f"{_esc(capital_raw)}千万円" if capital_raw else ""
+            capital_unit = _a(exp, "capital_unit", "千万円")
+            capital = f"{_esc(capital_raw)}{_esc(capital_unit)}" if capital_raw else ""
             emp = f"{_esc(emp_raw)}名" if emp_raw else ""
             info_parts = [f"事業内容：{biz}"]
             if capital:
@@ -188,17 +207,27 @@ def _build_html(resume: dict) -> str:
             )
             parts.append('<div class="company-body">')
 
-            # 取引先 → プロジェクト（後方互換含む正規化は shared に集約）
-            clients = normalize_clients(exp)
-            for client in clients:
-                client_name = _a(client, "name")
-                if client_name:
-                    parts.append(
-                        f'<div class="client-name">' f"取引先名：{_esc(client_name)}</div>",
-                    )
-                projects = _a(client, "projects", [])
-                for proj in projects:
-                    parts.append(_build_project_html(proj))
+            if not _a(exp, "is_it_company", True):
+                # 非IT企業: 取引先/プロジェクトの代わりに詳細を表示
+                detail = _a(exp, "description")
+                parts.append(
+                    f'<div class="company-detail">{_md(detail)}</div>' if detail else "<p>-</p>",
+                )
+            else:
+                # 取引先 → プロジェクト（後方互換含む正規化は shared に集約）
+                clients = normalize_clients(exp)
+                for client in clients:
+                    if _a(client, "is_vacation", False):
+                        parts.append(_build_vacation_html(client))
+                        continue
+                    client_name = _a(client, "name")
+                    if client_name:
+                        parts.append(
+                            f'<div class="client-name">' f"取引先名：{_esc(client_name)}</div>",
+                        )
+                    projects = _a(client, "projects", [])
+                    for proj in projects:
+                        parts.append(_build_project_html(proj))
 
             parts.append("</div></div>")
 

--- a/backend/app/services/pdf/templates/resume.css
+++ b/backend/app/services/pdf/templates/resume.css
@@ -67,6 +67,36 @@ h2 {
   padding: 4px;
 }
 
+/* 非IT企業の詳細（取引先/プロジェクトの代わり） */
+.company-detail {
+  font-size: 8pt;
+  line-height: 1.6;
+}
+
+.company-detail p {
+  margin: 0 0 0.5em 0;
+}
+
+/* 休暇エントリ */
+.vacation {
+  margin-bottom: 2mm;
+}
+
+.vacation-header {
+  font-size: 9pt;
+  font-weight: bold;
+  margin: 2mm 0 1mm 0;
+}
+
+.vacation-body {
+  font-size: 8pt;
+  line-height: 1.6;
+}
+
+.vacation-body p {
+  margin: 0 0 0.5em 0;
+}
+
 /* 取引先 */
 .client-name {
   font-size: 10pt;

--- a/backend/tests/test_contributions.py
+++ b/backend/tests/test_contributions.py
@@ -1,0 +1,158 @@
+"""
+GitHub コントリビューションカレンダー取得（GraphQL）のテスト。
+
+対象モジュール: app.services.intelligence.github.contributions
+テスト方針:
+  - httpx.AsyncClient をモック化し、実 GitHub API は叩かない
+  - 補助処理として失敗時に None を返す（例外を送出しない）ことを検証
+  - contributionLevel → 0–4 の正規化を検証
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from app.services.intelligence.github.contributions import (
+    _parse_calendar,
+    fetch_contribution_calendar,
+)
+
+
+def _run(coro):
+    """async 関数を同期的に実行するヘルパー。"""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_mock_client(*, status_code=200, payload=None, post_side_effect=None):
+    """POST レスポンスを返すモック AsyncClient を生成する。"""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    if post_side_effect is not None:
+        mock_client.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.json = MagicMock(return_value=payload or {})
+        mock_client.post = AsyncMock(return_value=mock_resp)
+    return mock_client
+
+
+_CALENDAR_PAYLOAD = {
+    "data": {
+        "user": {
+            "contributionsCollection": {
+                "contributionCalendar": {
+                    "totalContributions": 42,
+                    "weeks": [
+                        {
+                            "contributionDays": [
+                                {
+                                    "date": "2024-01-01",
+                                    "contributionCount": 0,
+                                    "contributionLevel": "NONE",
+                                },
+                                {
+                                    "date": "2024-01-02",
+                                    "contributionCount": 5,
+                                    "contributionLevel": "SECOND_QUARTILE",
+                                },
+                            ]
+                        },
+                        {
+                            "contributionDays": [
+                                {
+                                    "date": "2024-01-08",
+                                    "contributionCount": 12,
+                                    "contributionLevel": "FOURTH_QUARTILE",
+                                },
+                            ]
+                        },
+                    ],
+                }
+            }
+        }
+    }
+}
+
+
+def _patch_client(mock_client):
+    return patch(
+        "app.services.intelligence.github.contributions.httpx.AsyncClient",
+        return_value=mock_client,
+    )
+
+
+class TestFetchContributionCalendar:
+    def test_success_parses_calendar(self):
+        """正常系: totalContributions と週ごとの level が正しく取得されること。"""
+        with _patch_client(_make_mock_client(payload=_CALENDAR_PAYLOAD)):
+            calendar = _run(fetch_contribution_calendar("gh-user", "token123"))
+
+        assert calendar is not None
+        assert calendar.total_contributions == 42
+        assert len(calendar.weeks) == 2
+        # NONE → 0, SECOND_QUARTILE → 2, FOURTH_QUARTILE → 4
+        assert [d.level for d in calendar.weeks[0]] == [0, 2]
+        assert calendar.weeks[0][1].count == 5
+        assert calendar.weeks[1][0].level == 4
+        assert calendar.weeks[1][0].date == "2024-01-08"
+
+    def test_graphql_errors_returns_none(self):
+        """GraphQL errors を含む応答では None を返すこと。"""
+        payload = {"data": {"user": None}, "errors": [{"message": "Bad creds"}]}
+        with _patch_client(_make_mock_client(payload=payload)):
+            calendar = _run(fetch_contribution_calendar("gh-user", "token123"))
+        assert calendar is None
+
+    def test_user_none_returns_none(self):
+        """user が null の応答では None を返すこと。"""
+        payload = {"data": {"user": None}}
+        with _patch_client(_make_mock_client(payload=payload)):
+            calendar = _run(fetch_contribution_calendar("gh-user", "token123"))
+        assert calendar is None
+
+    def test_non_200_returns_none(self):
+        """HTTP 401 等では None を返すこと（例外を投げない）。"""
+        with _patch_client(_make_mock_client(status_code=401, payload={})):
+            calendar = _run(fetch_contribution_calendar("gh-user", "token123"))
+        assert calendar is None
+
+    def test_network_error_returns_none(self):
+        """ネットワーク障害でも例外を投げず None を返すこと（補助処理）。"""
+        with _patch_client(
+            _make_mock_client(post_side_effect=httpx.ConnectError("boom"))
+        ):
+            calendar = _run(fetch_contribution_calendar("gh-user", "token123"))
+        assert calendar is None
+
+
+class TestParseCalendar:
+    def test_level_mapping_and_defaults(self):
+        """contributionLevel が 0–4 に正規化され、未知値は 0 になること。"""
+        raw = {
+            "totalContributions": 3,
+            "weeks": [
+                {
+                    "contributionDays": [
+                        {"date": "2024-02-01", "contributionCount": 1, "contributionLevel": "FIRST_QUARTILE"},
+                        {"date": "2024-02-02", "contributionCount": 2, "contributionLevel": "THIRD_QUARTILE"},
+                        {"date": "2024-02-03", "contributionCount": 0, "contributionLevel": "UNKNOWN"},
+                    ]
+                }
+            ],
+        }
+        calendar = _parse_calendar(raw)
+        assert calendar.total_contributions == 3
+        assert [d.level for d in calendar.weeks[0]] == [1, 3, 0]
+
+    def test_empty_weeks(self):
+        """weeks が空でも壊れないこと。"""
+        calendar = _parse_calendar({"totalContributions": 0, "weeks": []})
+        assert calendar.total_contributions == 0
+        assert calendar.weeks == []

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -173,6 +173,91 @@ def test_resume_round_trips_nested_structure(client: TestClient) -> None:
     assert project["phases"] == ["基本設計", "開発"]
 
 
+def test_resume_round_trips_non_it_and_vacation(client: TestClient) -> None:
+    headers = auth_header(client, "resume-nonit-vacation-user")
+
+    payload = {
+        "full_name": "佐藤 花子",
+        "career_summary": "キャリアサマリー",
+        "self_pr": "自己PR",
+        "experiences": [
+            {
+                "company": "〇〇商事",
+                "business_description": "小売業",
+                "start_date": "2016-04",
+                "end_date": "2019-03",
+                "is_current": False,
+                "is_it_company": False,
+                "description": "店舗運営・在庫管理・スタッフ教育を担当",
+                "clients": [],
+            },
+            {
+                "company": "Example株式会社",
+                "business_description": "SES事業",
+                "start_date": "2019-04",
+                "end_date": "2024-03",
+                "is_current": False,
+                "is_it_company": True,
+                "clients": [
+                    {
+                        "is_vacation": True,
+                        "vacation_start_date": "2020-04",
+                        "vacation_end_date": "2021-03",
+                        "vacation_is_current": False,
+                        "vacation_description": "育児休暇を取得。期間中にProgateで学習",
+                    },
+                    {
+                        "name": "顧客A",
+                        "has_client": True,
+                        "projects": [
+                            {
+                                "name": "API開発",
+                                "periods": [
+                                    {
+                                        "start_date": "2021-04",
+                                        "end_date": "2024-03",
+                                        "is_current": False,
+                                    }
+                                ],
+                                "role": "SE",
+                                "description": "性能改善",
+                                "technology_stacks": [{"category": "language", "name": "Python"}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+        "qualifications": [],
+    }
+
+    resp = client.post("/api/resumes", json=payload, headers=headers)
+    assert resp.status_code == 201
+    resume_id = resp.json()["id"]
+
+    resp = client.get(f"/api/resumes/{resume_id}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # 経歴は在籍期間の降順（新しい在籍が先）でソートされる。
+    experiences = {exp["company"]: exp for exp in data["experiences"]}
+
+    non_it = experiences["〇〇商事"]
+    assert non_it["is_it_company"] is False
+    assert non_it["description"] == "店舗運営・在庫管理・スタッフ教育を担当"
+    assert non_it["clients"] == []
+
+    it_exp = experiences["Example株式会社"]
+    assert it_exp["is_it_company"] is True
+    vacation = next(c for c in it_exp["clients"] if c["is_vacation"])
+    assert vacation["vacation_start_date"] == "2020-04"
+    assert vacation["vacation_end_date"] == "2021-03"
+    assert vacation["vacation_description"] == "育児休暇を取得。期間中にProgateで学習"
+    normal = next(c for c in it_exp["clients"] if not c["is_vacation"])
+    assert normal["name"] == "顧客A"
+    assert normal["projects"][0]["name"] == "API開発"
+
+
 # ── Health Check ───────────────────────────────────────────────
 
 

--- a/backend/tests/test_markdown_generator.py
+++ b/backend/tests/test_markdown_generator.py
@@ -1,0 +1,135 @@
+from app.services.markdown.generators.resume_generator import build_resume_markdown
+
+
+def _payload(capital: str, capital_unit: str | None) -> dict:
+    exp: dict = {
+        "company": "Example株式会社",
+        "business_description": "SES事業",
+        "start_date": "2021-04",
+        "end_date": "2024-03",
+        "is_current": False,
+        "capital": capital,
+        "clients": [],
+    }
+    if capital_unit is not None:
+        exp["capital_unit"] = capital_unit
+    return {
+        "full_name": "山田 太郎",
+        "career_summary": "職務要約",
+        "self_pr": "自己PR",
+        "qualifications": [],
+        "experiences": [exp],
+    }
+
+
+def test_capital_unit_reflected_in_markdown() -> None:
+    md = build_resume_markdown(_payload("5", "百万円"))
+    assert "5百万円" in md
+    assert "千万円" not in md
+
+
+def test_capital_unit_defaults_to_sen_man_when_missing() -> None:
+    # capital_unit を持たない旧データは後方互換で「千万円」表示になる。
+    md = build_resume_markdown(_payload("5", None))
+    assert "5千万円" in md
+
+
+def _it_experience() -> dict:
+    return {
+        "company": "Example株式会社",
+        "business_description": "SES事業",
+        "start_date": "2019-04",
+        "end_date": "2024-03",
+        "is_current": False,
+        "is_it_company": True,
+        "clients": [
+            {
+                "name": "顧客A",
+                "has_client": True,
+                "is_vacation": False,
+                "projects": [
+                    {
+                        "name": "API開発",
+                        "periods": [
+                            {"start_date": "2021-04", "end_date": "2024-03", "is_current": False}
+                        ],
+                        "role": "SE",
+                        "description": "性能改善を担当",
+                        "technology_stacks": [{"category": "language", "name": "Python"}],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_non_it_experience_renders_description_without_project_table() -> None:
+    """非IT経歴は詳細を出力し、取引先/プロジェクト見出しを出さない。"""
+    payload = {
+        "full_name": "佐藤 花子",
+        "career_summary": "要約",
+        "self_pr": "自己PR",
+        "qualifications": [],
+        "experiences": [
+            {
+                "company": "〇〇商事",
+                "business_description": "小売業",
+                "start_date": "2016-04",
+                "end_date": "2019-03",
+                "is_current": False,
+                "is_it_company": False,
+                "description": "店舗運営・在庫管理を担当",
+                "clients": [],
+            }
+        ],
+    }
+
+    md = build_resume_markdown(payload)
+
+    assert "店舗運営・在庫管理を担当" in md
+    # 非IT経歴では取引先見出し（####）やプロジェクト見出し（#####）を出さない。
+    assert "####" not in md
+
+
+def test_vacation_client_renders_period_and_detail() -> None:
+    """休暇エントリは期間と詳細を出力する。"""
+    exp = _it_experience()
+    exp["clients"] = [
+        {
+            "is_vacation": True,
+            "vacation_start_date": "2020-04",
+            "vacation_end_date": "2021-03",
+            "vacation_is_current": False,
+            "vacation_description": "育児休暇を取得",
+        }
+    ]
+    payload = {
+        "full_name": "佐藤 花子",
+        "career_summary": "要約",
+        "self_pr": "自己PR",
+        "qualifications": [],
+        "experiences": [exp],
+    }
+
+    md = build_resume_markdown(payload)
+
+    assert "#### 休暇" in md
+    assert "2020-04 - 2021-03" in md
+    assert "育児休暇を取得" in md
+
+
+def test_it_experience_renders_projects_unchanged() -> None:
+    """既存のIT経路は取引先・プロジェクトを従来どおり出力する。"""
+    payload = {
+        "full_name": "山田 太郎",
+        "career_summary": "要約",
+        "self_pr": "自己PR",
+        "qualifications": [],
+        "experiences": [_it_experience()],
+    }
+
+    md = build_resume_markdown(payload)
+
+    assert "#### 顧客A" in md
+    assert "##### API開発" in md
+    assert "性能改善を担当" in md

--- a/backend/tests/test_pdf_generator.py
+++ b/backend/tests/test_pdf_generator.py
@@ -32,6 +32,50 @@ def test_build_resume_pdf_returns_pdf_bytes() -> None:
     assert len(pdf_bytes) > 100
 
 
+def test_build_resume_pdf_with_non_it_and_vacation() -> None:
+    """非IT経歴と休暇エントリを含む payload でも PDF を生成できる。"""
+    payload = {
+        "full_name": "佐藤 花子",
+        "qualifications": [],
+        "career_summary": "職務要約",
+        "self_pr": "自己PR",
+        "experiences": [
+            {
+                "company": "〇〇商事",
+                "business_description": "小売業",
+                "start_date": "2016-04",
+                "end_date": "2019-03",
+                "is_current": False,
+                "is_it_company": False,
+                "description": "店舗運営・在庫管理を担当",
+                "clients": [],
+            },
+            {
+                "company": "Example株式会社",
+                "business_description": "SES事業",
+                "start_date": "2019-04",
+                "end_date": "2024-03",
+                "is_current": False,
+                "is_it_company": True,
+                "clients": [
+                    {
+                        "is_vacation": True,
+                        "vacation_start_date": "2020-04",
+                        "vacation_end_date": "2021-03",
+                        "vacation_is_current": False,
+                        "vacation_description": "育児休暇を取得",
+                    }
+                ],
+            },
+        ],
+    }
+
+    pdf_bytes = build_resume_pdf(payload)
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 100
+
+
 def test_parse_date_ym() -> None:
     assert _parse_date_ym("2020-04") == ("2020", "4")
     assert _parse_date_ym("2020-12-01") == ("2020", "12")

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,5 +1,6 @@
 import pytest
 from app.schemas import (
+    Client,
     Experience,
     Project,
     ResumeCreate,
@@ -299,3 +300,73 @@ def test_project_end_date_none_is_rejected() -> None:
             is_current=True,
             technology_stacks=[],
         )
+
+
+def test_non_it_experience_with_description_and_no_clients() -> None:
+    """非IT経歴: is_it_company=False で取引先なし・詳細のみでも保存できる。"""
+    payload = experience_payload()
+    payload["is_it_company"] = False
+    payload["description"] = "店舗運営・在庫管理を担当"
+    payload["clients"] = []
+
+    exp = Experience(**payload)
+
+    assert exp.is_it_company is False
+    assert exp.description == "店舗運営・在庫管理を担当"
+    assert exp.clients == []
+
+
+def test_experience_defaults_to_it_company() -> None:
+    """経歴: is_it_company は既定 True（後方互換）。"""
+    exp = Experience(**experience_payload())
+    assert exp.is_it_company is True
+    assert exp.description == ""
+
+
+def test_vacation_client_accepts_valid_period() -> None:
+    """休暇: is_vacation=True で期間・詳細を保持できる。"""
+    client = Client(
+        is_vacation=True,
+        vacation_start_date="2020-04",
+        vacation_end_date="2021-03",
+        vacation_is_current=False,
+        vacation_description="育児休暇",
+    )
+    assert client.is_vacation is True
+    assert client.vacation_start_date == "2020-04"
+    assert client.vacation_end_date == "2021-03"
+
+
+def test_vacation_client_current_normalizes_end_to_empty() -> None:
+    """休暇: 継続中（vacation_is_current=True）なら終了年月は "" に正規化される。"""
+    client = Client(
+        is_vacation=True,
+        vacation_start_date="2020-04",
+        vacation_end_date="2021-03",
+        vacation_is_current=True,
+    )
+    assert client.vacation_end_date == ""
+
+
+def test_vacation_client_requires_start_date() -> None:
+    """休暇: 開始年月が空なら 422（日本語メッセージ）。"""
+    with pytest.raises(ValidationError, match="開始年月を入力してください"):
+        Client(is_vacation=True, vacation_start_date="", vacation_description="育児休暇")
+
+
+def test_vacation_client_end_before_start_is_rejected() -> None:
+    """休暇: 終了年月が開始年月より前ならエラー。"""
+    with pytest.raises(ValidationError, match="開始日は終了日より前"):
+        Client(
+            is_vacation=True,
+            vacation_start_date="2021-04",
+            vacation_end_date="2020-03",
+            vacation_is_current=False,
+        )
+
+
+def test_non_vacation_client_skips_vacation_validation() -> None:
+    """休暇でない取引先は vacation 期間が空でも検証対象外。"""
+    client = Client(name="クライアントA", has_client=True)
+    assert client.is_vacation is False
+    assert client.vacation_start_date == ""

--- a/backend/tests/test_worker/test_github_link.py
+++ b/backend/tests/test_worker/test_github_link.py
@@ -58,6 +58,11 @@ class TestRunGithubAnalysis:
                 return_value=repos,
             ),
             patch(
+                "app.services.intelligence.github_link_service.fetch_contribution_calendar",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
                 "app.services.progress_service.set_progress",
                 new_callable=AsyncMock,
             ),
@@ -108,6 +113,11 @@ class TestRunGithubAnalysis:
                 new_callable=AsyncMock,
                 return_value=repos,
             ),
+            patch(
+                "app.services.intelligence.github_link_service.fetch_contribution_calendar",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
             patch("app.services.progress_service.set_progress", new_callable=AsyncMock),
             patch(
                 "app.services.intelligence.github_link_service.decrypt_field",
@@ -143,6 +153,97 @@ class TestRunGithubAnalysis:
         assert cache.error_message is None
         assert cache.warning_message is None
         assert cache.completed_at is not None
+
+    def test_contribution_calendar_persisted_in_result(
+        self, db_session: Session, session_factory
+    ):
+        """コントリビューションカレンダーが取得できた場合、result に格納され
+        warning_message が立たないこと。"""
+        from app.schemas.github_link import ContributionCalendar, ContributionDay
+
+        user, cache = self._make_user_and_cache(db_session, "github:calendar-user")
+        repos = self._sample_repos()
+        calendar = ContributionCalendar(
+            total_contributions=7,
+            weeks=[[ContributionDay(date="2024-03-01", count=3, level=2)]],
+        )
+
+        with (
+            patch(
+                "app.services.intelligence.github_link_service.collect_repos",
+                new_callable=AsyncMock,
+                return_value=repos,
+            ),
+            patch(
+                "app.services.intelligence.github_link_service.fetch_contribution_calendar",
+                new_callable=AsyncMock,
+                return_value=calendar,
+            ),
+            patch("app.services.progress_service.set_progress", new_callable=AsyncMock),
+            patch(
+                "app.services.intelligence.github_link_service.decrypt_field",
+                return_value="token123",
+            ),
+        ):
+            _run(
+                _run_github_link(
+                    session_factory,
+                    {
+                        "user_id": user.id,
+                        "github_username": "gh-user",
+                        "github_token": "encrypted_token",
+                        "include_forks": False,
+                    },
+                )
+            )
+
+        db_session.refresh(cache)
+        assert cache.status == "completed"
+        assert cache.result["contribution_calendar"]["total_contributions"] == 7
+        assert cache.result["contribution_calendar"]["weeks"][0][0]["level"] == 2
+        assert cache.warning_message is None
+
+    def test_contribution_fetch_failure_sets_warning(
+        self, db_session: Session, session_factory
+    ):
+        """コントリビューション取得失敗（None）でも連携は completed のままで、
+        warning_message が立つこと。"""
+        user, cache = self._make_user_and_cache(db_session, "github:warn-user")
+        repos = self._sample_repos()
+
+        with (
+            patch(
+                "app.services.intelligence.github_link_service.collect_repos",
+                new_callable=AsyncMock,
+                return_value=repos,
+            ),
+            patch(
+                "app.services.intelligence.github_link_service.fetch_contribution_calendar",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("app.services.progress_service.set_progress", new_callable=AsyncMock),
+            patch(
+                "app.services.intelligence.github_link_service.decrypt_field",
+                return_value="token123",
+            ),
+        ):
+            _run(
+                _run_github_link(
+                    session_factory,
+                    {
+                        "user_id": user.id,
+                        "github_username": "gh-user",
+                        "github_token": "encrypted_token",
+                        "include_forks": False,
+                    },
+                )
+            )
+
+        db_session.refresh(cache)
+        assert cache.status == "completed"
+        assert cache.result["contribution_calendar"] is None
+        assert cache.warning_message is not None
 
     def test_status_transitions_to_processing_at_start(
         self, db_session: Session, session_factory

--- a/frontend/e2e/github-link.spec.ts
+++ b/frontend/e2e/github-link.spec.ts
@@ -86,4 +86,135 @@ test.describe("GitHub 連携 - 検出フレームワーク表示", () => {
       page.getByRole("heading", { name: "Frameworks" }),
     ).not.toBeVisible();
   });
+
+  test("コントリビューションカレンダーがあると Activity ヒートマップが表示される", async ({
+    page,
+  }) => {
+    await page.route("**/api/github-link/cache", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "completed",
+          result: {
+            username: "e2e-test-user",
+            repos_analyzed: 2,
+            unique_skills: 3,
+            analyzed_at: "2026-04-24T00:00:00Z",
+            languages: { TypeScript: 100 },
+            detected_frameworks: {},
+            detected_devtools: {},
+            detected_infras: {},
+            contribution_calendar: {
+              total_contributions: 256,
+              weeks: [[{ date: "2025-01-06", count: 4, level: 2 }]],
+            },
+          },
+        }),
+      }),
+    );
+
+    await page.goto("/github_link");
+    await waitForAuthenticatedLayout(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Activity" }),
+    ).toBeVisible();
+    await expect(page.getByText("年間コントリビュート")).toBeVisible();
+    await expect(page.getByText("256")).toBeVisible();
+
+    // ページは表示専用。連携トリガーボタン（更新する/再連携）は無い
+    await expect(
+      page.getByRole("button", { name: "更新する" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "再連携" }),
+    ).toHaveCount(0);
+  });
+
+  test("未連携時は空状態メッセージが表示され、ページに連携ボタンが無い", async ({
+    page,
+  }) => {
+    await page.route("**/api/github-link/cache", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: null, status: null }),
+      }),
+    );
+
+    await page.goto("/github_link");
+    await waitForAuthenticatedLayout(page);
+
+    await expect(page.getByText(/まだ連携データがありません/)).toBeVisible();
+    // トリガーはサイドバーのみ。ページ本文に連携ボタンは無い
+    await expect(
+      page.getByRole("button", { name: "連携する" }),
+    ).toHaveCount(0);
+  });
+
+  test("サイドバーの ▾ でフォーク含むオプションが開閉する", async ({
+    page,
+  }) => {
+    await page.route("**/api/github-link/cache", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: null, status: null }),
+      }),
+    );
+
+    await page.goto("/github_link");
+    await waitForAuthenticatedLayout(page);
+
+    // デフォルトでは非表示
+    await expect(
+      page.getByText("フォークしたリポジトリを含む"),
+    ).toHaveCount(0);
+
+    await page
+      .getByRole("button", { name: "GitHub連携オプション" })
+      .click();
+
+    await expect(
+      page.getByText("フォークしたリポジトリを含む"),
+    ).toBeVisible();
+  });
+
+  test("サイドバーの GitHub連携 クリックで連携が実行されポーリング表示になる", async ({
+    page,
+  }) => {
+    await page.route("**/api/github-link/cache", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: null, status: null }),
+      }),
+    );
+    await page.route("**/api/github-link/run", (route) =>
+      route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "pending" }),
+      }),
+    );
+    await page.route("**/api/github-link/cache/status", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "pending" }),
+      }),
+    );
+
+    await page.goto("/github_link");
+    await waitForAuthenticatedLayout(page);
+
+    await page
+      .getByRole("button", { name: "GitHub連携", exact: true })
+      .click();
+
+    await expect(
+      page.getByText("GitHubプロフィールを取得中..."),
+    ).toBeVisible();
+  });
 });

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -16,7 +16,10 @@ test.describe("認証済みユーザーのナビゲーション", () => {
 
     await expect(page.getByText("DevForge")).toBeVisible();
     await expect(page.getByRole("link", { name: "職務経歴書" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "GitHub連携" })).toBeVisible();
+    // GitHub連携 は連携トリガーを兼ねるためボタン
+    await expect(
+      page.getByRole("button", { name: "GitHub連携", exact: true }),
+    ).toBeVisible();
     await expect(page.getByRole("link", { name: "ブログ連携" })).toBeVisible();
   });
 

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -65,6 +65,67 @@
   padding-left: calc(1.2rem - 3px);
 }
 
+/* ── GitHub連携: 展開グループ（フォーク含むオプション）──────────── */
+
+.sidebarItemGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebarItemRow {
+  display: flex;
+  align-items: stretch;
+}
+
+.sidebarItemRow .sidebarItem {
+  flex: 1;
+  width: auto;
+}
+
+.sidebarChevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.9rem;
+  background: none;
+  border: none;
+  color: var(--sidebar-text);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.sidebarChevron:hover {
+  color: var(--sidebar-hover-text);
+  background: var(--sidebar-hover-bg);
+}
+
+.sidebarChevron svg {
+  transition: transform 0.15s ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.sidebarSubPanel {
+  padding: 0.5rem 1.2rem 0.7rem;
+}
+
+.sidebarCheckbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--sidebar-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.sidebarCheckbox input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+  cursor: pointer;
+}
+
 .sidebarFooter {
   margin-top: auto;
   padding: 0.6rem 0;

--- a/frontend/src/api/githubLink.ts
+++ b/frontend/src/api/githubLink.ts
@@ -14,6 +14,24 @@ export interface GitHubLinkPayload {
   include_forks?: boolean;
 }
 
+/** コントリビューションカレンダーの 1 日分 */
+export interface ContributionDay {
+  /** ISO 8601 形式の日付 (YYYY-MM-DD) */
+  date: string;
+  /** その日のコントリビューション数 */
+  count: number;
+  /** GitHub の濃淡レベル (0–4) */
+  level: number;
+}
+
+/** 直近1年のコントリビューションカレンダー（GitHub の緑の四角） */
+export interface ContributionCalendar {
+  /** 期間内のコントリビューション総数 */
+  total_contributions: number;
+  /** 週ごとの日配列（列=週、各週は最大7日） */
+  weeks: ContributionDay[][];
+}
+
 export interface GitHubLinkResponse {
   username: string;
   repos_analyzed: number;
@@ -26,6 +44,8 @@ export interface GitHubLinkResponse {
   detected_devtools: Record<string, number>;
   /** ルートファイルから検出したインフラツール名 → 使用リポジトリ数 */
   detected_infras: Record<string, number>;
+  /** 直近1年のコントリビューションカレンダー（取得失敗時は null） */
+  contribution_calendar?: ContributionCalendar | null;
 }
 
 export interface CachedGitHubLinkResponse {

--- a/frontend/src/components/AuthenticatedLayout.tsx
+++ b/frontend/src/components/AuthenticatedLayout.tsx
@@ -1,9 +1,11 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { useState } from "react";
+import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import type { AuthUser } from "../router/guards";
 import type { Theme } from "../hooks/useTheme";
 import { NotificationBell } from "./NotificationBell";
 import { UserMenu } from "./UserMenu";
+import { ChevronDownIcon } from "./icons/ChevronDownIcon";
 import shared from "../styles/shared.module.css";
 import styles from "../App.module.css";
 
@@ -22,6 +24,26 @@ export function AuthenticatedLayout({
   onToggleTheme: () => void;
   onLogout: () => void;
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  // GitHub 連携オプション（フォーク含む）の開閉とチェック状態。
+  const [githubOptionsOpen, setGithubOptionsOpen] = useState(false);
+  const [includeForks, setIncludeForks] = useState(false);
+
+  /**
+   * GitHub 連携を実行する。
+   * 連携 API のトリガーはこのサイドバークリックのみ。
+   * 実行意図を runNonce としてページへ渡し、ダッシュボード側で
+   * 連携実行（ポーリング）とエラー表示を担わせる。
+   */
+  const triggerGitHubLink = () => {
+    navigate("/github_link", {
+      state: { runNonce: Date.now(), includeForks },
+    });
+  };
+
+  const githubActive = location.pathname === "/github_link";
+
   return (
     <div className={shared.page}>
       <div className={styles.appLayout}>
@@ -37,14 +59,40 @@ export function AuthenticatedLayout({
               職務経歴書
             </NavLink>
             {user.isGitHubUser && (
-              <NavLink
-                to="/github_link"
-                className={({ isActive }) =>
-                  `${styles.sidebarItem} ${isActive ? styles.active : ""}`
-                }
-              >
-                GitHub連携
-              </NavLink>
+              <div className={styles.sidebarItemGroup}>
+                <div className={styles.sidebarItemRow}>
+                  <button
+                    type="button"
+                    className={`${styles.sidebarItem} ${githubActive ? styles.active : ""}`}
+                    onClick={triggerGitHubLink}
+                  >
+                    GitHub連携
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.sidebarChevron}
+                    aria-label="GitHub連携オプション"
+                    aria-expanded={githubOptionsOpen}
+                    onClick={() => setGithubOptionsOpen((open) => !open)}
+                  >
+                    <ChevronDownIcon
+                      className={githubOptionsOpen ? styles.chevronOpen : undefined}
+                    />
+                  </button>
+                </div>
+                {githubOptionsOpen && (
+                  <div className={styles.sidebarSubPanel}>
+                    <label className={styles.sidebarCheckbox}>
+                      <input
+                        type="checkbox"
+                        checked={includeForks}
+                        onChange={(e) => setIncludeForks(e.target.checked)}
+                      />
+                      フォークしたリポジトリを含む
+                    </label>
+                  </div>
+                )}
+              </div>
             )}
             <NavLink
               to="/blog"

--- a/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
@@ -1,3 +1,4 @@
+import { CAPITAL_UNITS } from "../../../constants";
 import type { CareerClientFieldKey, CareerExperienceFieldKey } from "../../../formTypes";
 import type { ExperienceDirty } from "../../../hooks/career/useCareerDirty";
 import {
@@ -31,6 +32,10 @@ type CareerExperienceEditorProps = {
   ) => void;
   /** 取引先「取引先なし」切替ハンドラ */
   onUpdateClientHasClient: (expIndex: number, clientIndex: number, value: boolean) => void;
+  /** 取引先「休暇」切替ハンドラ */
+  onUpdateClientIsVacation: (expIndex: number, clientIndex: number, value: boolean) => void;
+  /** 休暇「継続中」切替ハンドラ */
+  onUpdateClientVacationIsCurrent: (expIndex: number, clientIndex: number, value: boolean) => void;
   /** 取引先追加ハンドラ */
   onAddClient: (expIndex: number) => void;
   /** 取引先削除ハンドラ */
@@ -57,6 +62,8 @@ export function CareerExperienceEditor({
   onUpdateExperienceField,
   onUpdateClientField,
   onUpdateClientHasClient,
+  onUpdateClientIsVacation,
+  onUpdateClientVacationIsCurrent,
   onAddClient,
   onRemoveClient,
   onRemoveProject,
@@ -181,7 +188,7 @@ export function CareerExperienceEditor({
           <label>
             <span>
               資本金
-              <DirtyDot visible={Boolean(fieldDirty?.capital)} />
+              <DirtyDot visible={Boolean(fieldDirty?.capital || fieldDirty?.capital_unit)} />
             </span>
             <div className={styles.inputWithUnit}>
               <input
@@ -191,108 +198,261 @@ export function CareerExperienceEditor({
                 onChange={(e) => onUpdateExperienceField(expIndex, "capital", e.target.value)}
                 placeholder="例: 5"
               />
-              <span className={styles.unit}>千万円</span>
+              <select
+                className={styles.unitSelect}
+                value={exp.capital_unit}
+                onChange={(e) => onUpdateExperienceField(expIndex, "capital_unit", e.target.value)}
+                aria-label="資本金の単位"
+              >
+                {CAPITAL_UNITS.map((unit) => (
+                  <option key={unit} value={unit}>
+                    {unit}
+                  </option>
+                ))}
+              </select>
             </div>
           </label>
         </div>
 
-        {/* 取引先 */}
-        <div className={styles.stackSection}>
-          <h3>取引先</h3>
-          {exp.clients.map((client, clientIndex) => {
-            const clientDirty = dirty?.clients?.[clientIndex];
-            return (
-              <div key={`client-${expIndex}-${clientIndex}`} className={shared.entry}>
-                <div className={styles.clientHeader}>
-                  {client.has_client && (
-                    <label className={styles.clientNameLabel}>
+        {/* IT企業かどうか（非ITは取引先を持たず詳細のみ） */}
+        <label className={styles.clientCheckbox}>
+          <input
+            type="checkbox"
+            checked={exp.is_it_company}
+            onChange={(e) => onUpdateExperienceField(expIndex, "is_it_company", e.target.checked)}
+          />
+          <span>
+            IT企業
+            <DirtyDot visible={Boolean(fieldDirty?.is_it_company)} />
+          </span>
+        </label>
+
+        {!exp.is_it_company && (
+          <div className={styles.stackSection}>
+            <label>
+              <span className={shared.labelText}>
+                詳細
+                <span className={shared.requiredBadge}>必須</span>
+                <DirtyDot visible={Boolean(fieldDirty?.description)} />
+              </span>
+              <textarea
+                value={exp.description}
+                onChange={(e) =>
+                  onUpdateExperienceField(expIndex, "description", e.target.value)
+                }
+                rows={6}
+                placeholder="例: 店舗運営・在庫管理・スタッフ教育を担当…"
+              />
+            </label>
+          </div>
+        )}
+
+        {exp.is_it_company && (
+          <div className={styles.stackSection}>
+            <h3>取引先</h3>
+            {exp.clients.map((client, clientIndex) => {
+              const clientDirty = dirty?.clients?.[clientIndex];
+              return (
+                <div key={`client-${expIndex}-${clientIndex}`} className={shared.entry}>
+                  <div className={styles.clientHeader}>
+                    {!client.is_vacation && client.has_client && (
+                      <label className={styles.clientNameLabel}>
+                        <span>
+                          取引先名（呼称）
+                          <DirtyDot visible={Boolean(clientDirty?.self)} />
+                        </span>
+                        <input
+                          type="text"
+                          value={client.name}
+                          onChange={(e) =>
+                            onUpdateClientField(expIndex, clientIndex, "name", e.target.value)
+                          }
+                          placeholder="例: 〇〇社（略称）"
+                        />
+                      </label>
+                    )}
+                    {!client.is_vacation && (
+                      <label className={styles.clientCheckbox}>
+                        <input
+                          type="checkbox"
+                          checked={!client.has_client}
+                          onChange={(e) =>
+                            onUpdateClientHasClient(expIndex, clientIndex, !e.target.checked)
+                          }
+                        />
+                        {/* has_client=false で name 入力が消えた時にも未保存状態を可視化するため
+                          常時表示のチェックボックス側にも dot を出す。 */}
+                        <span>
+                          取引先なし
+                          <DirtyDot visible={Boolean(clientDirty?.self)} />
+                        </span>
+                      </label>
+                    )}
+                    <label className={styles.clientCheckbox}>
+                      <input
+                        type="checkbox"
+                        checked={client.is_vacation}
+                        onChange={(e) =>
+                          onUpdateClientIsVacation(expIndex, clientIndex, e.target.checked)
+                        }
+                      />
                       <span>
-                        取引先名（呼称）
+                        休暇
                         <DirtyDot visible={Boolean(clientDirty?.self)} />
                       </span>
-                      <input
-                        type="text"
-                        value={client.name}
-                        onChange={(e) =>
-                          onUpdateClientField(expIndex, clientIndex, "name", e.target.value)
-                        }
-                        placeholder="例: 〇〇社（略称）"
-                      />
                     </label>
-                  )}
-                  <label className={styles.clientCheckbox}>
-                    <input
-                      type="checkbox"
-                      checked={!client.has_client}
-                      onChange={(e) =>
-                        onUpdateClientHasClient(expIndex, clientIndex, !e.target.checked)
-                      }
-                    />
-                    {/* has_client=false で name 入力（と同じ行の DirtyDot）が消えた時にも
-                      未保存状態を可視化するため、常時表示のチェックボックス側にも dot を出す。 */}
-                    <span>
-                      取引先なし
-                      <DirtyDot visible={Boolean(clientDirty?.self)} />
-                    </span>
-                  </label>
-                </div>
+                  </div>
 
-                {/* プロジェクト一覧（サマリー表示） */}
-                <div className={styles.stackSection}>
-                  <h3>プロジェクト</h3>
-                  {client.projects.map((proj, projIndex) => {
-                    const projDirty = clientDirty?.projects?.[projIndex];
-                    return (
-                      <div
-                        key={`proj-${expIndex}-${clientIndex}-${projIndex}`}
-                        className={styles.projectSummaryRow}
-                      >
-                        <span className={styles.projectName}>
-                          {proj.name || "(未入力)"}
-                          <DirtyDot visible={Boolean(projDirty?.any)} />
-                        </span>
-                        <span className={styles.projectPeriod}>{projectSummary(proj)}</span>
-                        <div className={styles.projectActions}>
-                          <button
-                            type="button"
-                            onClick={() => onOpenProjectModal(expIndex, clientIndex, projIndex)}
+                  {client.is_vacation ? (
+                    /* 休暇: 期間 + 詳細 */
+                    <div className={styles.stackSection}>
+                      <div className={shared.inline}>
+                        <label>
+                          <span className={shared.labelText}>
+                            開始
+                            <span className={shared.requiredBadge}>必須</span>
+                          </span>
+                          <input
+                            type="month"
+                            value={client.vacation_start_date}
+                            onChange={(e) =>
+                              onUpdateClientField(
+                                expIndex,
+                                clientIndex,
+                                "vacation_start_date",
+                                e.target.value,
+                              )
+                            }
+                          />
+                        </label>
+                        <label>
+                          <span>継続の有無</span>
+                          <select
+                            value={client.vacation_is_current ? "current" : "ended"}
+                            onChange={(e) =>
+                              onUpdateClientVacationIsCurrent(
+                                expIndex,
+                                clientIndex,
+                                e.target.value === "current",
+                              )
+                            }
                           >
-                            編集
-                          </button>
-                          <button
-                            type="button"
-                            className="danger"
-                            onClick={() => onRemoveProject(expIndex, clientIndex, projIndex)}
-                          >
-                            削除
-                          </button>
-                        </div>
+                            <option value="ended">終了</option>
+                            <option value="current">継続中</option>
+                          </select>
+                        </label>
+                        {!client.vacation_is_current && (
+                          <label>
+                            <span className={shared.labelText}>
+                              終了
+                              <span className={shared.requiredBadge}>必須</span>
+                            </span>
+                            <input
+                              type="month"
+                              value={client.vacation_end_date}
+                              onChange={(e) =>
+                                onUpdateClientField(
+                                  expIndex,
+                                  clientIndex,
+                                  "vacation_end_date",
+                                  e.target.value,
+                                )
+                              }
+                            />
+                          </label>
+                        )}
                       </div>
-                    );
-                  })}
+                      {validateDateRange(
+                        client.vacation_start_date,
+                        client.vacation_end_date,
+                        client.vacation_is_current,
+                      ) && (
+                        <p className={shared.error} style={{ fontSize: "0.85rem" }}>
+                          {validateDateRange(
+                            client.vacation_start_date,
+                            client.vacation_end_date,
+                            client.vacation_is_current,
+                          )}
+                        </p>
+                      )}
+                      <label>
+                        <span className={shared.labelText}>詳細</span>
+                        <textarea
+                          value={client.vacation_description}
+                          onChange={(e) =>
+                            onUpdateClientField(
+                              expIndex,
+                              clientIndex,
+                              "vacation_description",
+                              e.target.value,
+                            )
+                          }
+                          rows={4}
+                          placeholder="例: 育児休暇を取得。期間中にProgateでJavaScriptを学習…"
+                        />
+                      </label>
+                    </div>
+                  ) : (
+                    /* プロジェクト一覧（サマリー表示） */
+                    <div className={styles.stackSection}>
+                      <h3>プロジェクト</h3>
+                      {client.projects.map((proj, projIndex) => {
+                        const projDirty = clientDirty?.projects?.[projIndex];
+                        return (
+                          <div
+                            key={`proj-${expIndex}-${clientIndex}-${projIndex}`}
+                            className={styles.projectSummaryRow}
+                          >
+                            <span className={styles.projectName}>
+                              {proj.name || "(未入力)"}
+                              <DirtyDot visible={Boolean(projDirty?.any)} />
+                            </span>
+                            <span className={styles.projectPeriod}>{projectSummary(proj)}</span>
+                            <div className={styles.projectActions}>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onOpenProjectModal(expIndex, clientIndex, projIndex)
+                                }
+                              >
+                                編集
+                              </button>
+                              <button
+                                type="button"
+                                className="danger"
+                                onClick={() => onRemoveProject(expIndex, clientIndex, projIndex)}
+                              >
+                                削除
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      <button
+                        type="button"
+                        className="ghost"
+                        onClick={() => onOpenProjectModal(expIndex, clientIndex, null)}
+                      >
+                        プロジェクトを追加
+                      </button>
+                    </div>
+                  )}
+
                   <button
                     type="button"
-                    className="ghost"
-                    onClick={() => onOpenProjectModal(expIndex, clientIndex, null)}
+                    className="danger"
+                    onClick={() => onRemoveClient(expIndex, clientIndex)}
                   >
-                    プロジェクトを追加
+                    取引先を削除
                   </button>
                 </div>
-
-                <button
-                  type="button"
-                  className="danger"
-                  onClick={() => onRemoveClient(expIndex, clientIndex)}
-                >
-                  取引先を削除
-                </button>
-              </div>
-            );
-          })}
-          <button type="button" className="ghost" onClick={() => onAddClient(expIndex)}>
-            取引先を追加
-          </button>
-        </div>
+              );
+            })}
+            <button type="button" className="ghost" onClick={() => onAddClient(expIndex)}>
+              取引先を追加
+            </button>
+          </div>
+        )}
 
         <button type="button" className="danger" onClick={() => onRemoveExperience(expIndex)}>
           職務経歴を削除

--- a/frontend/src/components/forms/CareerResumeForm.module.css
+++ b/frontend/src/components/forms/CareerResumeForm.module.css
@@ -14,6 +14,12 @@
   white-space: nowrap;
 }
 
+.unitSelect {
+  flex: 0 0 auto;
+  width: auto;
+  font-size: 0.85rem;
+}
+
 .stackSection {
   border-top: 1px solid var(--border);
   margin-top: 0.8rem;

--- a/frontend/src/components/forms/sections/CareerExperienceSection.tsx
+++ b/frontend/src/components/forms/sections/CareerExperienceSection.tsx
@@ -105,6 +105,8 @@ export function CareerExperienceSection({
           onUpdateExperienceField={mutators.updateExperienceField}
           onUpdateClientField={mutators.updateClientField}
           onUpdateClientHasClient={mutators.updateClientHasClient}
+          onUpdateClientIsVacation={mutators.updateClientIsVacation}
+          onUpdateClientVacationIsCurrent={mutators.updateClientVacationIsCurrent}
           onAddClient={mutators.addClient}
           onRemoveClient={mutators.removeClient}
           onRemoveProject={mutators.removeProject}

--- a/frontend/src/components/github-link/ContributionHeatmap.module.css
+++ b/frontend/src/components/github-link/ContributionHeatmap.module.css
@@ -1,0 +1,111 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── サマリー ─────────────────────────────────────────────── */
+
+.summary {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.statCard {
+  flex: 1;
+  min-width: 140px;
+  text-align: center;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+
+.statValue {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.statLabel {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+
+/* ── ヒートマップグリッド ───────────────────────────────────── */
+
+.scroll {
+  overflow-x: auto;
+  padding-bottom: 0.3rem;
+}
+
+.monthRow {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 3px;
+}
+
+.monthLabel {
+  width: 11px;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.grid {
+  display: flex;
+  gap: 3px;
+}
+
+.weekCol {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+  background: var(--contrib-l0);
+  flex-shrink: 0;
+}
+
+.l0 {
+  background: var(--contrib-l0);
+}
+
+.l1 {
+  background: var(--contrib-l1);
+}
+
+.l2 {
+  background: var(--contrib-l2);
+}
+
+.l3 {
+  background: var(--contrib-l3);
+}
+
+.l4 {
+  background: var(--contrib-l4);
+}
+
+/* ── 凡例 ─────────────────────────────────────────────────── */
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  justify-content: flex-end;
+}
+
+.legendText {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin: 0 0.3rem;
+}

--- a/frontend/src/components/github-link/ContributionHeatmap.test.tsx
+++ b/frontend/src/components/github-link/ContributionHeatmap.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ContributionHeatmap } from "./ContributionHeatmap";
+import type { ContributionCalendar } from "../../api";
+
+function makeCalendar(): ContributionCalendar {
+  return {
+    total_contributions: 15,
+    weeks: [
+      [
+        { date: "2024-01-01", count: 0, level: 0 },
+        { date: "2024-01-02", count: 4, level: 2 },
+        { date: "2024-01-03", count: 9, level: 4 },
+      ],
+      [
+        { date: "2024-02-05", count: 2, level: 1 },
+        { date: "2024-02-06", count: 0, level: 0 },
+      ],
+    ],
+  };
+}
+
+describe("ContributionHeatmap", () => {
+  it("年間コントリビュート総数を表示する", () => {
+    render(<ContributionHeatmap calendar={makeCalendar()} />);
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.getByText("年間コントリビュート")).toBeInTheDocument();
+  });
+
+  it("各日セルに日付とコントリビューション数の title を付ける", () => {
+    render(<ContributionHeatmap calendar={makeCalendar()} />);
+    expect(
+      screen.getByTitle("2024-01-03: 9 contributions"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTitle("2024-02-05: 2 contributions"),
+    ).toBeInTheDocument();
+  });
+
+  it("最大連続日数を算出する（count>0 の連続セル）", () => {
+    // 実データは全日が連続して並ぶ。0 で途切れ、最大連続は 3。
+    const calendar: ContributionCalendar = {
+      total_contributions: 6,
+      weeks: [
+        [
+          { date: "2024-03-01", count: 1, level: 1 },
+          { date: "2024-03-02", count: 2, level: 1 },
+          { date: "2024-03-03", count: 3, level: 2 },
+          { date: "2024-03-04", count: 0, level: 0 },
+          { date: "2024-03-05", count: 5, level: 3 },
+        ],
+      ],
+    };
+    render(<ContributionHeatmap calendar={calendar} />);
+    expect(screen.getByText("最大連続日数")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("月が変わる週に月ラベルを表示する", () => {
+    render(<ContributionHeatmap calendar={makeCalendar()} />);
+    expect(screen.getByText("Jan")).toBeInTheDocument();
+    expect(screen.getByText("Feb")).toBeInTheDocument();
+  });
+
+  it("空の weeks でもクラッシュしない", () => {
+    render(
+      <ContributionHeatmap
+        calendar={{ total_contributions: 0, weeks: [] }}
+      />,
+    );
+    // total=0 / streak=0 の 2 枚のカードが描画される
+    expect(screen.getAllByText("0")).toHaveLength(2);
+    expect(screen.getByText("最大連続日数")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/github-link/ContributionHeatmap.tsx
+++ b/frontend/src/components/github-link/ContributionHeatmap.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import type { ContributionCalendar, ContributionDay } from "../../api";
+import styles from "./ContributionHeatmap.module.css";
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const LEVEL_CLASSES = [styles.l0, styles.l1, styles.l2, styles.l3, styles.l4];
+
+interface ContributionHeatmapProps {
+  calendar: ContributionCalendar;
+}
+
+/**
+ * GitHub プロフィールの「緑の四角」を再現するコントリビューションヒートマップ。
+ * 列=週・行=曜日でセルを並べ、濃淡レベル (0–4) で色分けする。
+ * 年間コントリビュート数と最大連続日数のサマリーも表示する。
+ */
+export function ContributionHeatmap({ calendar }: ContributionHeatmapProps) {
+  /** 各週の先頭日から月ラベルを算出する（前の週から月が変わる週にのみ表示） */
+  const monthLabels = useMemo(() => {
+    const monthOf = (week: ContributionDay[]) =>
+      week[0] ? new Date(week[0].date).getMonth() : -1;
+    return calendar.weeks.map((week, i) => {
+      const month = monthOf(week);
+      if (month < 0) return "";
+      const prevMonth = i > 0 ? monthOf(calendar.weeks[i - 1]) : -1;
+      return month !== prevMonth ? MONTH_NAMES[month] : "";
+    });
+  }, [calendar.weeks]);
+
+  /** 連続コントリビュート日数の最大値を算出する */
+  const longestStreak = useMemo(() => {
+    let longest = 0;
+    let current = 0;
+    for (const day of calendar.weeks.flat()) {
+      if (day.count > 0) {
+        current += 1;
+        longest = Math.max(longest, current);
+      } else {
+        current = 0;
+      }
+    }
+    return longest;
+  }, [calendar.weeks]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.summary}>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{calendar.total_contributions}</div>
+          <div className={styles.statLabel}>年間コントリビュート</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{longestStreak}</div>
+          <div className={styles.statLabel}>最大連続日数</div>
+        </div>
+      </div>
+
+      <div
+        className={styles.scroll}
+        role="img"
+        aria-label={`過去1年のコントリビューション (合計 ${calendar.total_contributions})`}
+      >
+        <div className={styles.monthRow}>
+          {monthLabels.map((label, i) => (
+            <span key={i} className={styles.monthLabel}>
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className={styles.grid}>
+          {calendar.weeks.map((week, wi) => (
+            <div key={wi} className={styles.weekCol}>
+              {week.map((day) => (
+                <span
+                  key={day.date}
+                  className={`${styles.cell} ${LEVEL_CLASSES[day.level] ?? styles.l0}`}
+                  title={`${day.date}: ${day.count} contributions`}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.legend}>
+        <span className={styles.legendText}>Less</span>
+        {LEVEL_CLASSES.map((cls, i) => (
+          <span key={i} className={`${styles.cell} ${cls}`} />
+        ))}
+        <span className={styles.legendText}>More</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/github-link/GitHubLinkDashboard.module.css
+++ b/frontend/src/components/github-link/GitHubLinkDashboard.module.css
@@ -72,9 +72,25 @@
 }
 
 .analyzeButton {
-  width: 100%;
-  padding: 0.8rem;
-  font-size: 1rem;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+/* ── 空状態 ─────────────────────────────────────────────────── */
+
+.emptyState {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--text-muted);
+  border: 1px dashed var(--border-dashed);
+  border-radius: 10px;
+  background: var(--bg-section);
+}
+
+.emptyState p {
+  margin: 0;
+  font-size: 0.95rem;
 }
 
 .errorMessage {

--- a/frontend/src/components/github-link/GitHubLinkDashboard.test.tsx
+++ b/frontend/src/components/github-link/GitHubLinkDashboard.test.tsx
@@ -1,19 +1,32 @@
 import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../test/mswServer";
 import { GitHubLinkDashboard } from "./GitHubLinkDashboard";
 import { renderWithProviders } from "../../test/renderWithProviders";
 
-/** Provider 付きでレンダリングするヘルパー */
+/** Provider 付きでレンダリングするヘルパー（表示のみ） */
 function renderPage() {
   return renderWithProviders(<GitHubLinkDashboard />);
 }
 
 /**
- * `GET /api/github-link/cache` をキャッシュ未保存（入力画面表示）レスポンスに差し替える。
- * 2 箇所でコピペされていた server.use ブロックを集約する。
+ * サイドバーから連携実行された状態（runNonce を含む location state）で描画する。
+ * 連携 API のトリガーはサイドバークリックのみのため、テストでも state 経由で再現する。
+ */
+function renderPageWithRun(includeForks = false) {
+  return renderWithProviders(<GitHubLinkDashboard />, {
+    initialEntries: [
+      {
+        pathname: "/github_link",
+        state: { runNonce: 1, includeForks },
+      },
+    ],
+  });
+}
+
+/**
+ * `GET /api/github-link/cache` をキャッシュ未保存（空状態）レスポンスに差し替える。
  */
 function mockEmptyCache() {
   server.use(
@@ -27,15 +40,30 @@ function mockEmptyCache() {
 }
 
 describe("GitHubLinkDashboard", () => {
-  it("キャッシュなしの場合、入力画面が表示される", async () => {
+  it("キャッシュなしの場合、空状態メッセージが表示される", async () => {
     mockEmptyCache();
 
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText("連携開始")).toBeInTheDocument();
+      expect(
+        screen.getByText(/まだ連携データがありません/),
+      ).toBeInTheDocument();
     });
     expect(screen.getByText("GitHub連携")).toBeInTheDocument();
+  });
+
+  it("表示専用: ページ上に連携トリガーボタン（連携する/更新する/再連携）が無い", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("test-user-001 の連携結果"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("連携する")).not.toBeInTheDocument();
+    expect(screen.queryByText("更新する")).not.toBeInTheDocument();
+    expect(screen.queryByText("再連携")).not.toBeInTheDocument();
   });
 
   it("キャッシュが存在する場合、結果画面が表示される", async () => {
@@ -48,6 +76,16 @@ describe("GitHubLinkDashboard", () => {
     });
     expect(screen.getByText("10")).toBeInTheDocument(); // repos_analyzed
     expect(screen.getByText("リポジトリ")).toBeInTheDocument();
+  });
+
+  it("コントリビューションカレンダーがあると Activity ヒートマップが表示される", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeInTheDocument();
+    });
+    expect(screen.getByText("年間コントリビュート")).toBeInTheDocument();
+    expect(screen.getByText("123")).toBeInTheDocument();
   });
 
   it("検出フレームワークがあるとき Frameworks セクションにバーが表示される", async () => {
@@ -108,9 +146,7 @@ describe("GitHubLinkDashboard", () => {
     expect(screen.queryByText("Frameworks")).not.toBeInTheDocument();
   });
 
-  it("連携開始ボタン押下後、ポーリング画面に遷移する", async () => {
-    const user = userEvent.setup();
-
+  it("サイドバーからの連携実行(runNonce)でポーリング画面に遷移する", async () => {
     mockEmptyCache();
     server.use(
       http.get("*/api/github-link/cache/status", () =>
@@ -118,13 +154,7 @@ describe("GitHubLinkDashboard", () => {
       ),
     );
 
-    renderPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("連携開始")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("連携開始"));
+    renderPageWithRun();
 
     await waitFor(() => {
       expect(
@@ -133,9 +163,7 @@ describe("GitHubLinkDashboard", () => {
     });
   });
 
-  it("API 500 エラー時にエラーメッセージが表示される", async () => {
-    const user = userEvent.setup();
-
+  it("連携実行が 503 を返したときエラーメッセージが表示される", async () => {
     mockEmptyCache();
     server.use(
       http.post("*/api/github-link/run", () =>
@@ -150,36 +178,14 @@ describe("GitHubLinkDashboard", () => {
       ),
     );
 
-    renderPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("連携開始")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("連携開始"));
+    renderPageWithRun();
 
     await waitFor(() => {
       // エラーメッセージが表示されること（アプリがクラッシュしないこと）
-      expect(screen.getByText(/AI 分析サービスが一時的に利用できません/)).toBeInTheDocument();
-      expect(screen.getByText(/エラーID: err-ui-500/)).toBeInTheDocument();
-    });
-  });
-
-  it("再連携ボタンで入力画面に戻る", async () => {
-    const user = userEvent.setup();
-
-    renderPage();
-
-    await waitFor(() => {
       expect(
-        screen.getByText("test-user-001 の連携結果"),
+        screen.getByText(/AI 分析サービスが一時的に利用できません/),
       ).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("再連携"));
-
-    await waitFor(() => {
-      expect(screen.getByText("連携開始")).toBeInTheDocument();
+      expect(screen.getByText(/エラーID: err-ui-500/)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/github-link/GitHubLinkDashboard.tsx
+++ b/frontend/src/components/github-link/GitHubLinkDashboard.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import {
   runGitHubLink,
   getGitHubLinkCache,
@@ -10,45 +11,47 @@ import {
 import { ErrorToast } from "../ui/ErrorToast";
 import { InlineSpinner } from "../ui/InlineSpinner";
 import { AsyncTaskLoading } from "../ui/AsyncTaskLoading";
-import { LOADING_MESSAGES } from "../../constants/messages";
+import { LOADING_MESSAGES, UI_MESSAGES } from "../../constants/messages";
 import { useAsyncTaskPage } from "../../hooks/useAsyncTaskPage";
+import { ContributionHeatmap } from "./ContributionHeatmap";
 import { LanguageBar } from "./LanguageBar";
 import { TechBar } from "./TechBar";
 import shared from "../../styles/shared.module.css";
 import styles from "./GitHubLinkDashboard.module.css";
 
+/** サイドバーから渡される連携実行の意図 */
+type GitHubLinkNavState = {
+  runNonce?: number;
+  includeForks?: boolean;
+} | null;
+
 /**
- * GitHub 連携結果を表示するダッシュボードコンポーネント。
+ * GitHub 連携結果を表示するダッシュボードコンポーネント（表示専用）。
  * 初回表示時にDBキャッシュを読み込み、保存済みの結果があればそのまま表示する。
- * 「再連携」ボタン押下時のみパイプラインを再実行する。
  *
- * 職務経歴書ページと同様に、フェーズ（読み込み/入力/ポーリング/結果）に関わらず
- * `shared.pageHeader` のタイトルバーを常時表示する。
+ * 連携 API のトリガーはサイドバーの「GitHub連携」クリックのみ。
+ * サイドバーは navigate state に runNonce を載せて遷移し、本コンポーネントが
+ * それを検知して連携を実行（ポーリング）・エラー表示を担う。
  */
 export function GitHubLinkDashboard() {
-  const [includeForks, setIncludeForks] = useState(false);
+  const location = useLocation();
+  const handledNonceRef = useRef<number | undefined>(undefined);
 
-  const {
-    phase,
-    result,
-    setResult,
-    error,
-    setError,
-    transitionToPolling,
-    backToInput,
-  } = useAsyncTaskPage<GitHubLinkResponse>({
-    loadCache: async () => {
-      const cache = await getGitHubLinkCache();
-      return { result: cache.result, status: cache.status };
-    },
-    checkStatus: getGitHubLinkCacheStatus,
-    fetchProgress: getGitHubLinkProgress,
-  });
+  const { phase, result, error, setError, transitionToPolling } =
+    useAsyncTaskPage<GitHubLinkResponse>({
+      loadCache: async () => {
+        const cache = await getGitHubLinkCache();
+        return { result: cache.result, status: cache.status };
+      },
+      checkStatus: getGitHubLinkCacheStatus,
+      fetchProgress: getGitHubLinkProgress,
+    });
 
   /**
-   * GitHub 連携を開始します（非同期バックグラウンド）。
+   * GitHub 連携を実行する（非同期バックグラウンド）。
+   * サイドバーから渡された includeForks を使う。
    */
-  const handleRun = async () => {
+  const runLink = async (includeForks: boolean) => {
     setError(null);
     try {
       await runGitHubLink({ include_forks: includeForks });
@@ -58,137 +61,114 @@ export function GitHubLinkDashboard() {
     }
   };
 
-  /**
-   * 入力画面に戻ります（再連携用）。
-   */
-  const handleBack = () => {
-    setResult(null);
-    backToInput();
-  };
+  // サイドバーからの実行意図（runNonce）を検知して連携を実行する。
+  useEffect(() => {
+    const state = location.state as GitHubLinkNavState;
+    if (state?.runNonce && state.runNonce !== handledNonceRef.current) {
+      handledNonceRef.current = state.runNonce;
+      void runLink(state.includeForks ?? false);
+    }
+    // location.state（サイドバークリック）変化時のみトリガーする
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.state]);
 
   /**
    * フェーズごとの本体を描画する。
    * ヘッダーは常時表示するため、ここでは pageBody に収める中身のみを返す。
    */
   const renderBody = () => {
-    // ── フェーズ: キャッシュ読み込み中 ──────────────────────────────
     if (phase === "loading-cache") {
       return <InlineSpinner label="読み込み中..." />;
     }
 
-    // ── フェーズ: 入力 ──────────────────────────────────────────
-    if (phase === "input") {
-      return (
-        <div className={styles.inputCard}>
-          <p>あなたのGitHubアクティビティからスキルとキャリアを可視化します</p>
-
-          <div className={styles.advancedOptions}>
-            <div className={styles.checkbox}>
-              <input
-                type="checkbox"
-                id="includeForks"
-                checked={includeForks}
-                onChange={(e) => setIncludeForks(e.target.checked)}
-              />
-              <label htmlFor="includeForks">フォークしたリポジトリを含む</label>
-            </div>
-          </div>
-
-          <button
-            type="button"
-            className={styles.analyzeButton}
-            onClick={handleRun}
-          >
-            連携開始
-          </button>
-
-          {error && (
-            <ErrorToast
-              code={error.code}
-              message={error.message}
-              action={error.action}
-              errorId={error.errorId}
-              onRetry={handleRun}
-            />
-          )}
-        </div>
-      );
-    }
-
-    // ── フェーズ: ポーリング中 ────────────────────────────────────────
     if (phase === "polling") {
       return <AsyncTaskLoading label={LOADING_MESSAGES.GITHUB_LINK} />;
     }
 
-    // ── フェーズ: 連携結果ダッシュボード ───────────────────────────────
-    if (!result) return null;
-
+    // ── 入力 / 結果フェーズ ─────────────────────────────────────────
     return (
       <div className={styles.dashboard}>
-        {/* ユーザー名見出し（再連携ボタンはページヘッダーへ移設済み） */}
-        <div className={styles.dashboardHeader}>
-          <h1>{result.username} の連携結果</h1>
-        </div>
-
         {error && (
           <ErrorToast
             code={error.code}
             message={error.message}
             action={error.action}
             errorId={error.errorId}
-            onRetry={handleRun}
           />
         )}
 
-        {/* 概要 */}
-        <div className={styles.section}>
-          <h2>Overview</h2>
-          <div className={styles.overviewCards}>
-            <div className={styles.statCard}>
-              <div className={styles.statValue}>{result.repos_analyzed}</div>
-              <div className={styles.statLabel}>リポジトリ</div>
-            </div>
-            <div className={styles.statCard}>
-              <div className={styles.statValue}>{result.unique_skills}</div>
-              <div className={styles.statLabel}>スキル</div>
-            </div>
+        {!result ? (
+          <div className={styles.emptyState}>
+            <p>{UI_MESSAGES.GITHUB_LINK_EMPTY}</p>
           </div>
-        </div>
+        ) : (
+          <>
+            <div className={styles.dashboardHeader}>
+              <h1>{result.username} の連携結果</h1>
+            </div>
 
-        {/* 構成 */}
-        {result.languages && Object.keys(result.languages).length > 0 && (
-          <div className={styles.section}>
-            <h2>Languages</h2>
-            <LanguageBar languages={result.languages} />
-          </div>
+            {/* アクティビティ（コントリビューションヒートマップ） */}
+            {result.contribution_calendar && (
+              <div className={styles.section}>
+                <h2>Activity</h2>
+                <ContributionHeatmap calendar={result.contribution_calendar} />
+              </div>
+            )}
+
+            {/* 概要 */}
+            <div className={styles.section}>
+              <h2>Overview</h2>
+              <div className={styles.overviewCards}>
+                <div className={styles.statCard}>
+                  <div className={styles.statValue}>{result.repos_analyzed}</div>
+                  <div className={styles.statLabel}>リポジトリ</div>
+                </div>
+                <div className={styles.statCard}>
+                  <div className={styles.statValue}>{result.unique_skills}</div>
+                  <div className={styles.statLabel}>スキル</div>
+                </div>
+              </div>
+            </div>
+
+            {/* 構成 */}
+            {result.languages && Object.keys(result.languages).length > 0 && (
+              <div className={styles.section}>
+                <h2>Languages</h2>
+                <LanguageBar languages={result.languages} />
+              </div>
+            )}
+
+            {/* 検出フレームワーク */}
+            {result.detected_frameworks &&
+              Object.keys(result.detected_frameworks).length > 0 && (
+                <div className={styles.section}>
+                  <h2>Frameworks</h2>
+                  <TechBar
+                    techs={result.detected_frameworks}
+                    ariaLabel="検出フレームワーク一覧"
+                  />
+                </div>
+              )}
+
+            {/* DevTools */}
+            {result.detected_devtools &&
+              Object.keys(result.detected_devtools).length > 0 && (
+                <div className={styles.section}>
+                  <h2>DevTools</h2>
+                  <TechBar techs={result.detected_devtools} />
+                </div>
+              )}
+
+            {/* インフラ */}
+            {result.detected_infras &&
+              Object.keys(result.detected_infras).length > 0 && (
+                <div className={styles.section}>
+                  <h2>Infra</h2>
+                  <TechBar techs={result.detected_infras} />
+                </div>
+              )}
+          </>
         )}
-
-        {/* 検出フレームワーク */}
-        {result.detected_frameworks &&
-          Object.keys(result.detected_frameworks).length > 0 && (
-            <div className={styles.section}>
-              <h2>Frameworks</h2>
-              <TechBar techs={result.detected_frameworks} ariaLabel="検出フレームワーク一覧" />
-            </div>
-          )}
-
-        {/* DevTools */}
-        {result.detected_devtools &&
-          Object.keys(result.detected_devtools).length > 0 && (
-            <div className={styles.section}>
-              <h2>DevTools</h2>
-              <TechBar techs={result.detected_devtools} />
-            </div>
-          )}
-
-        {/* インフラ */}
-        {result.detected_infras &&
-          Object.keys(result.detected_infras).length > 0 && (
-            <div className={styles.section}>
-              <h2>Infra</h2>
-              <TechBar techs={result.detected_infras} />
-            </div>
-          )}
       </div>
     );
   };
@@ -197,13 +177,6 @@ export function GitHubLinkDashboard() {
     <>
       <div className={shared.pageHeader}>
         <h1>GitHub連携</h1>
-        {phase === "result" && result && (
-          <div className={shared.pageHeaderActions}>
-            <button type="button" onClick={handleBack}>
-              再連携
-            </button>
-          </div>
-        )}
       </div>
       <div className={shared.pageBody}>{renderBody()}</div>
     </>

--- a/frontend/src/components/icons/ChevronDownIcon.tsx
+++ b/frontend/src/components/icons/ChevronDownIcon.tsx
@@ -1,0 +1,15 @@
+export function ChevronDownIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 448 512"
+      width="14"
+      height="14"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z" />
+    </svg>
+  );
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,4 +1,4 @@
-import type { CareerTechnologyStackCategory, ResumeQualification } from "./types";
+import type { CapitalUnit, CareerTechnologyStackCategory, ResumeQualification } from "./types";
 import type {
   CareerClientForm,
   CareerExperienceForm,
@@ -12,6 +12,12 @@ export const blankResumeQualification: ResumeQualification = {
   acquired_date: "",
   name: "",
 };
+
+/** 資本金の単位の選択肢（ドロップダウン表示順）。backend の Literal と手動同期。 */
+export const CAPITAL_UNITS: readonly CapitalUnit[] = ["万円", "百万円", "千万円", "億円"];
+
+/** 資本金の単位の既定値（後方互換のため「千万円」）。 */
+export const DEFAULT_CAPITAL_UNIT: CapitalUnit = "千万円";
 
 export const careerTechnologyStackCategories: CareerTechnologyStackCategory[] = [
   "language",
@@ -101,6 +107,11 @@ export const blankCareerClient: CareerClientForm = {
   name: "",
   has_client: true,
   projects: [{ ...blankCareerProject, technology_stacks: [{ ...blankCareerTechnologyStack }] }],
+  is_vacation: false,
+  vacation_start_date: "",
+  vacation_end_date: "",
+  vacation_is_current: false,
+  vacation_description: "",
 };
 
 export const blankCareerExperience: CareerExperienceForm = {
@@ -111,5 +122,8 @@ export const blankCareerExperience: CareerExperienceForm = {
   is_current: false,
   employee_count: "",
   capital: "",
+  capital_unit: DEFAULT_CAPITAL_UNIT,
+  is_it_company: true,
+  description: "",
   clients: [{ ...blankCareerClient }],
 };

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -23,6 +23,9 @@ export const VALIDATION_MESSAGES = {
   SELF_PR_REQUIRED: "自己PRを入力してください。",
   EXPERIENCE_REQUIRED_FIELDS: "職務経歴は会社名、事業内容、開始年月を入力してください。",
   EXPERIENCE_END_DATE_REQUIRED: "職務経歴の離職年月を入力するか、在職を選択してください。",
+  EXPERIENCE_DESCRIPTION_REQUIRED: "非IT企業の職務経歴は詳細を入力してください。",
+  VACATION_START_DATE_REQUIRED: "休暇の開始年月を入力してください。",
+  VACATION_END_DATE_REQUIRED: "休暇の終了年月を入力するか、継続中を選択してください。",
   PROJECT_START_DATE_REQUIRED: "プロジェクトの開始年月を入力してください。",
   PROJECT_END_DATE_REQUIRED: "プロジェクトの終了年月を入力するか、参画中を選択してください。",
   DATE_RANGE_INVALID: "開始日は終了日より前に設定してください。",
@@ -66,6 +69,8 @@ export const UI_MESSAGES = {
   ERROR_BOUNDARY_TITLE: "予期しないエラーが発生しました",
   ERROR_BOUNDARY_BODY:
     "ページの表示中に問題が発生しました。再読み込みするか、ホームへ戻ってください。",
+  GITHUB_LINK_EMPTY:
+    "まだ連携データがありません。連携してアクティビティを可視化しましょう。",
 } as const;
 
 /** PDF 取り込み補助（PDF ビュー上の選択 → 流し込み）UI の文言 */

--- a/frontend/src/formMappers.ts
+++ b/frontend/src/formMappers.ts
@@ -28,10 +28,17 @@ export function mapCareerResumeToForm(response: CareerResumeResponse): CareerFor
       response.experiences.length > 0
         ? response.experiences.map((experience) => ({
           ...experience,
+          is_it_company: experience.is_it_company ?? true,
+          description: experience.description ?? "",
           clients:
             experience.clients.length > 0
               ? experience.clients.map((client) => ({
                 ...client,
+                is_vacation: client.is_vacation ?? false,
+                vacation_start_date: client.vacation_start_date ?? "",
+                vacation_end_date: client.vacation_end_date ?? "",
+                vacation_is_current: client.vacation_is_current ?? false,
+                vacation_description: client.vacation_description ?? "",
                 projects:
                   client.projects.length > 0
                     ? client.projects.map((project) => ({

--- a/frontend/src/formTypes.ts
+++ b/frontend/src/formTypes.ts
@@ -6,7 +6,14 @@ export type CareerExperienceFieldKey =
   | "end_date"
   | "is_current"
   | "employee_count"
-  | "capital";
-export type CareerClientFieldKey = "name";
+  | "capital"
+  | "capital_unit"
+  | "is_it_company"
+  | "description";
+export type CareerClientFieldKey =
+  | "name"
+  | "vacation_start_date"
+  | "vacation_end_date"
+  | "vacation_description";
 export type CareerProjectFieldKey = "name" | "role" | "description";
 export type CareerProjectPeriodFieldKey = "start_date" | "end_date" | "is_current";

--- a/frontend/src/hooks/career/useCareerDirty.ts
+++ b/frontend/src/hooks/career/useCareerDirty.ts
@@ -37,6 +37,9 @@ export type ExperienceDirty = {
     is_current: boolean;
     employee_count: boolean;
     capital: boolean;
+    capital_unit: boolean;
+    is_it_company: boolean;
+    description: boolean;
   };
   clients: ClientDirty[];
 };
@@ -81,6 +84,9 @@ function buildCleanExperience(
       is_current: false,
       employee_count: false,
       capital: false,
+      capital_unit: false,
+      is_it_company: false,
+      description: false,
     },
     clients: experience.clients.map((c) => ({
       any: false,
@@ -130,7 +136,13 @@ function diffClient(
     };
   }
   const selfFieldsDirty =
-    current.name !== base.name || current.has_client !== base.has_client;
+    current.name !== base.name ||
+    current.has_client !== base.has_client ||
+    current.is_vacation !== base.is_vacation ||
+    current.vacation_start_date !== base.vacation_start_date ||
+    current.vacation_end_date !== base.vacation_end_date ||
+    current.vacation_is_current !== base.vacation_is_current ||
+    current.vacation_description !== base.vacation_description;
   const projects = current.projects.map((p, i) => diffProject(p, base.projects[i]));
   const removedProjects = current.projects.length !== base.projects.length;
   const any =
@@ -156,6 +168,9 @@ function diffExperience(
         is_current: true,
         employee_count: true,
         capital: true,
+        capital_unit: true,
+        is_it_company: true,
+        description: true,
       },
       clients: current.clients.map((c) => ({
         any: true,
@@ -172,6 +187,9 @@ function diffExperience(
     is_current: current.is_current !== base.is_current,
     employee_count: current.employee_count !== base.employee_count,
     capital: current.capital !== base.capital,
+    capital_unit: current.capital_unit !== base.capital_unit,
+    is_it_company: current.is_it_company !== base.is_it_company,
+    description: current.description !== base.description,
   };
   const self = Object.values(fields).some(Boolean);
   const clients = current.clients.map((c, i) => diffClient(c, base.clients[i]));

--- a/frontend/src/hooks/career/useCareerExperienceMutators.test.ts
+++ b/frontend/src/hooks/career/useCareerExperienceMutators.test.ts
@@ -102,6 +102,89 @@ describe("useCareerExperienceMutators", () => {
     });
   });
 
+  describe("updateExperienceField (is_it_company)", () => {
+    it("is_it_company を false にできる（非IT切替）", () => {
+      const { result } = setup(buildForm());
+      act(() => {
+        result.current.mutators.updateExperienceField(0, "is_it_company", false);
+      });
+      expect(result.current.form.experiences[0].is_it_company).toBe(false);
+    });
+
+    it("description フィールドを更新できる", () => {
+      const { result } = setup(buildForm());
+      act(() => {
+        result.current.mutators.updateExperienceField(0, "description", "店舗運営を担当");
+      });
+      expect(result.current.form.experiences[0].description).toBe("店舗運営を担当");
+    });
+  });
+
+  describe("updateClientIsVacation", () => {
+    it("休暇フラグを true/false に切り替える", () => {
+      const { result } = setup(buildForm());
+      act(() => {
+        result.current.mutators.updateClientIsVacation(0, 0, true);
+      });
+      expect(result.current.form.experiences[0].clients[0].is_vacation).toBe(true);
+      act(() => {
+        result.current.mutators.updateClientIsVacation(0, 0, false);
+      });
+      expect(result.current.form.experiences[0].clients[0].is_vacation).toBe(false);
+    });
+  });
+
+  describe("updateClientVacationIsCurrent", () => {
+    it("継続中を true にすると vacation_end_date がクリアされる", () => {
+      const form = buildForm();
+      form.experiences[0].clients[0] = {
+        ...form.experiences[0].clients[0],
+        is_vacation: true,
+        vacation_start_date: "2020-04",
+        vacation_end_date: "2021-03",
+        vacation_is_current: false,
+      };
+      const { result } = setup(form);
+      act(() => {
+        result.current.mutators.updateClientVacationIsCurrent(0, 0, true);
+      });
+      const client = result.current.form.experiences[0].clients[0];
+      expect(client.vacation_is_current).toBe(true);
+      expect(client.vacation_end_date).toBe("");
+    });
+
+    it("継続中を false にしても vacation_end_date は保持される", () => {
+      const form = buildForm();
+      form.experiences[0].clients[0] = {
+        ...form.experiences[0].clients[0],
+        is_vacation: true,
+        vacation_start_date: "2020-04",
+        vacation_end_date: "2021-03",
+        vacation_is_current: true,
+      };
+      const { result } = setup(form);
+      act(() => {
+        result.current.mutators.updateClientVacationIsCurrent(0, 0, false);
+      });
+      expect(result.current.form.experiences[0].clients[0].vacation_end_date).toBe("2021-03");
+    });
+  });
+
+  describe("updateClientField (vacation fields)", () => {
+    it("vacation_start_date / vacation_description を更新できる", () => {
+      const { result } = setup(buildForm());
+      act(() => {
+        result.current.mutators.updateClientField(0, 0, "vacation_start_date", "2020-04");
+      });
+      act(() => {
+        result.current.mutators.updateClientField(0, 0, "vacation_description", "育児休暇");
+      });
+      const client = result.current.form.experiences[0].clients[0];
+      expect(client.vacation_start_date).toBe("2020-04");
+      expect(client.vacation_description).toBe("育児休暇");
+    });
+  });
+
   describe("removeExperience", () => {
     it("最後の1件は削除せず blank で置換する", () => {
       const { result } = setup(buildForm());

--- a/frontend/src/hooks/career/useCareerExperienceMutators.ts
+++ b/frontend/src/hooks/career/useCareerExperienceMutators.ts
@@ -80,6 +80,48 @@ export function useCareerExperienceMutators(
     }));
   };
 
+  /** 「休暇」フラグ切り替えハンドラ */
+  const updateClientIsVacation = (expIndex: number, clientIndex: number, value: boolean) => {
+    setForm((prev) => ({
+      ...prev,
+      experiences: prev.experiences.map((exp, ei) => {
+        if (ei !== expIndex) return exp;
+        return {
+          ...exp,
+          clients: exp.clients.map((c, ci) =>
+            ci === clientIndex ? { ...c, is_vacation: value } : c,
+          ),
+        };
+      }),
+    }));
+  };
+
+  /** 休暇の「継続中」フラグ切り替えハンドラ（継続中なら終了年月をクリア） */
+  const updateClientVacationIsCurrent = (
+    expIndex: number,
+    clientIndex: number,
+    value: boolean,
+  ) => {
+    setForm((prev) => ({
+      ...prev,
+      experiences: prev.experiences.map((exp, ei) => {
+        if (ei !== expIndex) return exp;
+        return {
+          ...exp,
+          clients: exp.clients.map((c, ci) =>
+            ci === clientIndex
+              ? {
+                ...c,
+                vacation_is_current: value,
+                vacation_end_date: value ? "" : c.vacation_end_date,
+              }
+              : c,
+          ),
+        };
+      }),
+    }));
+  };
+
   /** 取引先追加ハンドラ */
   const addClient = (expIndex: number) => {
     setForm((prev) => ({
@@ -198,6 +240,8 @@ export function useCareerExperienceMutators(
     updateExperienceField,
     updateClientField,
     updateClientHasClient,
+    updateClientIsVacation,
+    updateClientVacationIsCurrent,
     addClient,
     removeClient,
     removeProject,

--- a/frontend/src/payloadBuilders.test.ts
+++ b/frontend/src/payloadBuilders.test.ts
@@ -4,6 +4,7 @@ import {
   buildCareerPayload,
   hasAnyText,
   validateDateRange,
+  type CareerClientForm,
   type CareerExperienceForm,
   type CareerFormState,
   type CareerProjectForm,
@@ -30,6 +31,18 @@ const blankProject = (overrides: Partial<CareerProjectForm> = {}): CareerProject
   ...overrides,
 });
 
+const blankClient = (overrides: Partial<CareerClientForm> = {}): CareerClientForm => ({
+  name: "",
+  has_client: true,
+  projects: [],
+  is_vacation: false,
+  vacation_start_date: "",
+  vacation_end_date: "",
+  vacation_is_current: false,
+  vacation_description: "",
+  ...overrides,
+});
+
 const blankExperience = (overrides: Partial<CareerExperienceForm> = {}): CareerExperienceForm => ({
   company: "Acme",
   business_description: "Web",
@@ -38,6 +51,9 @@ const blankExperience = (overrides: Partial<CareerExperienceForm> = {}): CareerE
   is_current: false,
   employee_count: "",
   capital: "",
+  capital_unit: "千万円",
+  is_it_company: true,
+  description: "",
   clients: [],
   ...overrides,
 });
@@ -170,6 +186,16 @@ describe("buildCareerPayload (experiences)", () => {
     ).toThrow(/会社名/);
   });
 
+  it("capital_unit が payload にそのまま引き継がれる", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [blankExperience({ capital: "5", capital_unit: "百万円" })],
+      }),
+    );
+    expect(payload.experiences[0].capital).toBe("5");
+    expect(payload.experiences[0].capital_unit).toBe("百万円");
+  });
+
   it("空欄だけの experience は filter で除外され、エラーにならない", () => {
     const payload = buildCareerPayload(
       baseState({
@@ -196,7 +222,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "顧客A",
                 has_client: true,
                 projects: [
@@ -204,7 +230,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
                     periods: [blankPeriod({ is_current: true, end_date: "2024-12" })],
                   }),
                 ],
-              },
+              }),
             ],
           }),
         ],
@@ -222,11 +248,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
           experiences: [
             blankExperience({
               clients: [
-                {
+                blankClient({
                   name: "顧客A",
                   has_client: true,
                   projects: [blankProject({ periods: [blankPeriod({ start_date: "" })] })],
-                },
+                }),
               ],
             }),
           ],
@@ -242,11 +268,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
           experiences: [
             blankExperience({
               clients: [
-                {
+                blankClient({
                   name: "顧客A",
                   has_client: true,
                   projects: [blankProject({ name: "P", description: "詳細", periods: [] })],
-                },
+                }),
               ],
             }),
           ],
@@ -262,13 +288,13 @@ describe("buildCareerPayload (projects/clients/team)", () => {
           experiences: [
             blankExperience({
               clients: [
-                {
+                blankClient({
                   name: "顧客A",
                   has_client: true,
                   projects: [
                     blankProject({ periods: [blankPeriod({ is_current: false, end_date: "" })] }),
                   ],
-                },
+                }),
               ],
             }),
           ],
@@ -283,11 +309,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "捨てられる",
                 has_client: false,
                 projects: [blankProject()],
-              },
+              }),
             ],
           }),
         ],
@@ -303,11 +329,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "",
                 has_client: true,
                 projects: [],
-              },
+              }),
             ],
           }),
         ],
@@ -322,11 +348,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "C",
                 has_client: true,
                 projects: [blankProject({ team: { total: "3", members: [] } })],
-              },
+              }),
             ],
           }),
         ],
@@ -342,7 +368,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "C",
                 has_client: true,
                 projects: [
@@ -358,7 +384,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
                     },
                   }),
                 ],
-              },
+              }),
             ],
           }),
         ],
@@ -377,7 +403,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "C",
                 has_client: true,
                 projects: [
@@ -389,7 +415,7 @@ describe("buildCareerPayload (projects/clients/team)", () => {
                     ],
                   }),
                 ],
-              },
+              }),
             ],
           }),
         ],
@@ -408,11 +434,11 @@ describe("buildCareerPayload (projects/clients/team)", () => {
         experiences: [
           blankExperience({
             clients: [
-              {
+              blankClient({
                 name: "C",
                 has_client: true,
                 projects: [blankProject({ name: "", description: "開発の詳細" })],
-              },
+              }),
             ],
           }),
         ],
@@ -421,6 +447,174 @@ describe("buildCareerPayload (projects/clients/team)", () => {
     const project = payload.experiences[0].clients[0].projects[0];
     expect(project.name).toBe("");
     expect(project.description).toBe("開発の詳細");
+  });
+});
+
+// ── 非IT企業の経歴 ────────────────────────────────────────────
+
+describe("buildCareerPayload (non-IT experience)", () => {
+  it("非ITは clients が空配列になり description が trim 保持される", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [
+          blankExperience({
+            is_it_company: false,
+            description: "  店舗運営を担当  ",
+            clients: [blankClient({ name: "捨てられる", projects: [blankProject()] })],
+          }),
+        ],
+      }),
+    );
+    expect(payload.experiences[0].is_it_company).toBe(false);
+    expect(payload.experiences[0].description).toBe("店舗運営を担当");
+    expect(payload.experiences[0].clients).toEqual([]);
+  });
+
+  it("非ITで description が空ならエラー", () => {
+    expect(() =>
+      buildCareerPayload(
+        baseState({
+          experiences: [blankExperience({ is_it_company: false, description: "   " })],
+        }),
+      ),
+    ).toThrow(/詳細/);
+  });
+
+  it("ITの場合 description は空文字に正規化され clients が残る", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [
+          blankExperience({
+            is_it_company: true,
+            description: "無視される",
+            clients: [blankClient({ name: "顧客A", projects: [blankProject()] })],
+          }),
+        ],
+      }),
+    );
+    expect(payload.experiences[0].description).toBe("");
+    expect(payload.experiences[0].clients).toHaveLength(1);
+  });
+});
+
+// ── 休暇エントリ ──────────────────────────────────────────────
+
+describe("buildCareerPayload (vacation client)", () => {
+  it("休暇は projects 空・name 空で vacation_* が trim 保持される", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [
+          blankExperience({
+            clients: [
+              blankClient({
+                is_vacation: true,
+                vacation_start_date: " 2020-04 ",
+                vacation_end_date: " 2021-03 ",
+                vacation_description: " 育児休暇 ",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const client = payload.experiences[0].clients[0];
+    expect(client.is_vacation).toBe(true);
+    expect(client.name).toBe("");
+    expect(client.projects).toEqual([]);
+    expect(client.vacation_start_date).toBe("2020-04");
+    expect(client.vacation_end_date).toBe("2021-03");
+    expect(client.vacation_description).toBe("育児休暇");
+  });
+
+  it("休暇が継続中なら vacation_end_date は空文字に正規化される", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [
+          blankExperience({
+            clients: [
+              blankClient({
+                is_vacation: true,
+                vacation_start_date: "2020-04",
+                vacation_end_date: "2021-03",
+                vacation_is_current: true,
+                vacation_description: "育児休暇",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(payload.experiences[0].clients[0].vacation_end_date).toBe("");
+  });
+
+  it("休暇で開始年月が空ならエラー", () => {
+    expect(() =>
+      buildCareerPayload(
+        baseState({
+          experiences: [
+            blankExperience({
+              clients: [
+                blankClient({
+                  is_vacation: true,
+                  vacation_start_date: "",
+                  vacation_description: "育児休暇",
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/休暇の開始年月/);
+  });
+
+  it("休暇で継続中でなく終了年月が空ならエラー", () => {
+    expect(() =>
+      buildCareerPayload(
+        baseState({
+          experiences: [
+            blankExperience({
+              clients: [
+                blankClient({
+                  is_vacation: true,
+                  vacation_start_date: "2020-04",
+                  vacation_end_date: "",
+                  vacation_is_current: false,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/休暇の終了年月/);
+  });
+
+  it("休暇で終了年月が開始年月より前ならエラー", () => {
+    expect(() =>
+      buildCareerPayload(
+        baseState({
+          experiences: [
+            blankExperience({
+              clients: [
+                blankClient({
+                  is_vacation: true,
+                  vacation_start_date: "2021-04",
+                  vacation_end_date: "2020-03",
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/開始日/);
+  });
+
+  it("中身が空の休暇エントリは除外される", () => {
+    const payload = buildCareerPayload(
+      baseState({
+        experiences: [blankExperience({ clients: [blankClient({ is_vacation: true })] })],
+      }),
+    );
+    expect(payload.experiences[0].clients).toEqual([]);
   });
 });
 

--- a/frontend/src/payloadBuilders.ts
+++ b/frontend/src/payloadBuilders.ts
@@ -1,5 +1,6 @@
 import { VALIDATION_MESSAGES } from "./constants/messages";
 import type {
+  CapitalUnit,
   CareerClient,
   CareerExperience,
   CareerProject,
@@ -39,6 +40,11 @@ export type CareerClientForm = {
   name: string;
   has_client: boolean;
   projects: CareerProjectForm[];
+  is_vacation: boolean;
+  vacation_start_date: string;
+  vacation_end_date: string;
+  vacation_is_current: boolean;
+  vacation_description: string;
 };
 
 export type CareerExperienceForm = {
@@ -49,6 +55,9 @@ export type CareerExperienceForm = {
   is_current: boolean;
   employee_count: string;
   capital: string;
+  capital_unit: CapitalUnit;
+  is_it_company: boolean;
+  description: string;
   clients: CareerClientForm[];
 };
 
@@ -120,12 +129,29 @@ function buildProject(proj: CareerProjectForm): CareerProject {
 }
 
 function buildClient(client: CareerClientForm): CareerClient {
+  if (client.is_vacation) {
+    return {
+      name: "",
+      has_client: client.has_client,
+      projects: [],
+      is_vacation: true,
+      vacation_start_date: client.vacation_start_date.trim(),
+      vacation_end_date: client.vacation_is_current ? "" : client.vacation_end_date.trim(),
+      vacation_is_current: client.vacation_is_current,
+      vacation_description: client.vacation_description.trim(),
+    };
+  }
   return {
     name: client.has_client ? client.name.trim() : "",
     has_client: client.has_client,
     projects: client.projects
       .map(buildProject)
       .filter((p) => hasAnyText([p.name, p.description])),
+    is_vacation: false,
+    vacation_start_date: "",
+    vacation_end_date: "",
+    vacation_is_current: false,
+    vacation_description: "",
   };
 }
 
@@ -154,9 +180,18 @@ export function buildCareerPayload(state: CareerFormState): CareerResumePayload 
       is_current: exp.is_current,
       employee_count: exp.employee_count.trim(),
       capital: exp.capital.trim(),
-      clients: exp.clients
-        .map(buildClient)
-        .filter((c) => !c.has_client || c.name.trim() || c.projects.length > 0),
+      capital_unit: exp.capital_unit,
+      is_it_company: exp.is_it_company,
+      description: exp.is_it_company ? "" : exp.description.trim(),
+      clients: exp.is_it_company
+        ? exp.clients
+            .map(buildClient)
+            .filter((c) =>
+              c.is_vacation
+                ? hasAnyText([c.vacation_start_date, c.vacation_end_date, c.vacation_description])
+                : !c.has_client || c.name.trim() || c.projects.length > 0,
+            )
+        : [],
     }))
     .filter((exp) =>
       hasAnyText([exp.company, exp.business_description, exp.start_date, exp.end_date]),
@@ -172,7 +207,30 @@ export function buildCareerPayload(state: CareerFormState): CareerResumePayload 
     if (!exp.is_current && exp.start_date && exp.end_date && exp.end_date < exp.start_date) {
       throw new Error(VALIDATION_MESSAGES.DATE_RANGE_INVALID);
     }
+    if (!exp.is_it_company) {
+      if (!exp.description) {
+        throw new Error(VALIDATION_MESSAGES.EXPERIENCE_DESCRIPTION_REQUIRED);
+      }
+      continue;
+    }
     for (const client of exp.clients) {
+      if (client.is_vacation) {
+        if (!client.vacation_start_date) {
+          throw new Error(VALIDATION_MESSAGES.VACATION_START_DATE_REQUIRED);
+        }
+        if (!client.vacation_is_current && !client.vacation_end_date) {
+          throw new Error(VALIDATION_MESSAGES.VACATION_END_DATE_REQUIRED);
+        }
+        if (
+          !client.vacation_is_current &&
+          client.vacation_start_date &&
+          client.vacation_end_date &&
+          client.vacation_end_date < client.vacation_start_date
+        ) {
+          throw new Error(VALIDATION_MESSAGES.DATE_RANGE_INVALID);
+        }
+        continue;
+      }
       for (const proj of client.projects) {
         // 内容のあるプロジェクトは periods が 1 件以上あり、各期間の開始年月が必須。
         if (proj.periods.length === 0) {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -74,6 +74,13 @@
   --github-hover: #3b4249;
   --photo-placeholder-bg: #f5f0ea;
   --overlay-bg: rgba(0, 0, 0, 0.5);
+
+  /* Contribution heatmap（GitHub の緑の四角・濃淡 0–4） */
+  --contrib-l0: #ebedf0;
+  --contrib-l1: #9be9a8;
+  --contrib-l2: #40c463;
+  --contrib-l3: #30a14e;
+  --contrib-l4: #216e39;
 }
 
 [data-theme="dark"] {
@@ -135,6 +142,13 @@
   --github-hover: #2d2d2d;
   --photo-placeholder-bg: #292524;
   --overlay-bg: rgba(0, 0, 0, 0.7);
+
+  /* Contribution heatmap（GitHub の緑の四角・濃淡 0–4） */
+  --contrib-l0: #2d2a26;
+  --contrib-l1: #0e4429;
+  --contrib-l2: #006d32;
+  --contrib-l3: #26a641;
+  --contrib-l4: #39d353;
 }
 
 * {

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -33,6 +33,15 @@ const analysisCacheResult = http.get("*/api/github-link/cache", () =>
       detected_frameworks: { React: 3, FastAPI: 2 },
       detected_devtools: { Docker: 4, "GitHub Actions": 3 },
       detected_infras: { Terraform: 1 },
+      contribution_calendar: {
+        total_contributions: 123,
+        weeks: [
+          [
+            { date: "2025-01-06", count: 2, level: 1 },
+            { date: "2025-01-07", count: 8, level: 4 },
+          ],
+        ],
+      },
     },
   }),
 );

--- a/frontend/src/test/renderWithProviders.tsx
+++ b/frontend/src/test/renderWithProviders.tsx
@@ -5,12 +5,13 @@
 import { type ReactElement } from "react";
 import { render, type RenderOptions } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, type MemoryRouterProps } from "react-router-dom";
 import { configureStore } from "@reduxjs/toolkit";
 import formCacheReducer from "../store/formCacheSlice";
 
 interface Options extends Omit<RenderOptions, "wrapper"> {
-  initialEntries?: string[];
+  /** 文字列パス、または state を含む location オブジェクトを渡せる */
+  initialEntries?: MemoryRouterProps["initialEntries"];
 }
 
 export function renderWithProviders(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -68,7 +68,16 @@ export type CareerClient = {
   name: string;
   has_client: boolean;
   projects: CareerProject[];
+  /** 休暇エントリか。true のとき取引先ではなく在籍中の休暇を表し vacation_* を使う。 */
+  is_vacation: boolean;
+  vacation_start_date: string;
+  vacation_end_date: string;
+  vacation_is_current: boolean;
+  vacation_description: string;
 };
+
+/** 資本金の単位。backend schemas/resume.py の Experience.capital_unit と対の DTO。 */
+export type CapitalUnit = "万円" | "百万円" | "千万円" | "億円";
 
 export type CareerExperience = {
   company: string;
@@ -78,6 +87,11 @@ export type CareerExperience = {
   is_current: boolean;
   employee_count: string;
   capital: string;
+  capital_unit: CapitalUnit;
+  /** IT 企業かどうか。false（非IT）の場合は取引先/プロジェクトを持たず description を使う。 */
+  is_it_company: boolean;
+  /** 非IT企業の職務内容を記述する自由記述欄（見出し「詳細」）。 */
+  description: string;
   clients: CareerClient[];
 };
 

--- a/frontend/tests/payloadBuilders.test.cjs
+++ b/frontend/tests/payloadBuilders.test.cjs
@@ -17,6 +17,7 @@ test("buildCareerPayload trims data and keeps only non-empty technology stacks",
         is_current: true,
         employee_count: "  300名  ",
         capital: "  1億円  ",
+        is_it_company: true,
         clients: [
           {
             has_client: true,
@@ -124,6 +125,7 @@ test("buildCareerPayload throws when 離職で終了年月がない", () => {
             is_current: false,
             employee_count: "100名",
             capital: "5000万円",
+            is_it_company: true,
             clients: []
           }
         ],


### PR DESCRIPTION
## 概要

職務経歴書（Resume）を IT エンジニア以外の経歴にも対応させた。在籍企業を「非IT企業」としてマークすると取引先/プロジェクトの代わりに自由記述の「詳細」を入力でき、在籍中の「休暇」（育児/介護/留学等）を取引先と並べて期間・詳細付きで記述できる。あわせて資本金の単位を企業ごとに選択可能にした（従来は「千万円」固定）。

同コミットには GitHub 連携ダッシュボードのコントリビューション可視化（緑の四角ヒートマップ）と連携UI刷新も含まれる（詳細は `report/pr_github_contributions.md`）。

## 背景・目的

従来の職務経歴書は「IT企業の取引先 → プロジェクト」という構造に固定されており、次のケースを表現できなかった:

1. **非IT企業での職歴**: 取引先/プロジェクト単位ではなく、職務内容を自由記述したい
2. **在籍中の休暇**: 育児・介護・留学などのブランクを職歴上で説明したい
3. **資本金の単位**: 企業規模により「万円/百万円/千万円/億円」を使い分けたい（従来は全社「千万円」固定で実態とずれていた）

## 変更内容

### Backend

- **モデル拡張** (`models/resume.py`)
  - `ResumeExperience` に `capital_unit`（既定「千万円」）/ `is_it_company`（既定 True）/ `description`（非IT時の詳細）を追加
  - `ResumeClient` に `is_vacation` / `vacation_start_date` / `vacation_end_date` / `vacation_is_current` / `vacation_description` を追加。`vacation_start_date` / `vacation_end_date` は `format_year_month` を通す read プロパティで `YYYY-MM` 文字列化（NULL は `""`）
- **マイグレーション 2 件** (`alembic_migrations/versions/`)
  - `0039_add_capital_unit`: `capital_unit` を追加（既存行の後方互換として `server_default="千万円"`）
  - `0040_add_resume_non_it_and_vacation`: 非IT フラグ/詳細・休暇カラム群を追加（`is_it_company` は既存行を IT 企業前提として `server_default=1`、`is_vacation` は `0`）
  - libSQL は ADD COLUMN を直接サポートするため upgrade は `op.add_column`、downgrade の列削除は ALTER/DROP 非対応のため `batch_alter_table`（テーブル再作成）
- **スキーマ + バリデーション** (`schemas/resume.py`)
  - `Experience` に `capital_unit: Literal["万円","百万円","千万円","億円"]` / `is_it_company` / `description` を追加
  - `Client` に休暇フィールド群を追加し、`validate_vacation_dates`（`mode="after"`）で休暇時のみ開始年月必須・継続中なら end を `""` に正規化・`end >= start` を検証（`Experience.validate_dates` と同契約）
- **永続化** (`repositories/resume.py`): 新フィールドを payload から読み出して行を構築。休暇期間は `parse_year_month` で日付化
- **生成系**
  - Markdown (`markdown/generators/resume_generator.py`): 資本金は `{cap}{capital_unit}` を出力。非IT企業は取引先ループをスキップし「詳細」を出力。休暇エントリは「#### 休暇」+ 期間 + 詳細
  - PDF (`pdf/generators/resume_generator.py` + `templates/resume.css`): `_build_vacation_html` を追加。非IT企業は `.company-detail` に詳細を表示、休暇は `.vacation` ブロックで表示。資本金単位を反映

### Frontend

- **型・定数** (`types.ts`, `formTypes.ts`, `constants.ts`)
  - `CapitalUnit` 型（backend `Literal` と手動同期）、`CAPITAL_UNITS` / `DEFAULT_CAPITAL_UNIT` を追加
  - `CareerExperience` / `CareerClient` に新フィールドを追加。blank テンプレートにも初期値を反映
- **経歴エディタ** (`forms/CareerFormEditors/CareerExperienceEditor.tsx`)
  - 資本金にドロップダウン（`CAPITAL_UNITS`）を追加
  - 「IT企業」チェックボックスを追加。OFF にすると取引先セクションを隠し「詳細」自由記述欄（必須）を表示
  - 取引先に「休暇」トグルを追加。ON で取引先名/プロジェクトの代わりに期間（開始/終了 or 継続中）+ 詳細を入力
- **フォーム入出力**
  - `formMappers.ts`: API レスポンスの新フィールドを `?? デフォルト` で吸収（後方互換）
  - `payloadBuilders.ts`: 非IT企業は `description` のみ送信し clients を空に、休暇 client は `vacation_*` のみ送信。事前バリデーション（詳細必須・休暇期間必須・期間整合）を追加
- **メッセージ** (`constants/messages.ts`): `EXPERIENCE_DESCRIPTION_REQUIRED` / `VACATION_START_DATE_REQUIRED` / `VACATION_END_DATE_REQUIRED` を `VALIDATION_MESSAGES` に追加

## 動作確認

- Backend: `make test-backend` / `make lint-backend`
  - 新規/更新テスト: `test_schemas.py`（capital_unit / is_it_company / 休暇バリデーション）、`test_markdown_generator.py`・`test_pdf_generator.py`（非IT詳細・休暇・資本金単位の出力）、`test_endpoints.py`、`test_contributions.py`、`test_worker/test_github_link.py`
- Frontend: `make lint-frontend` / `make lint-frontend-messages`、unit tests（`payloadBuilders.test.ts` に非IT/休暇の送信・バリデーション、`useCareerExperienceMutators.test.ts`、`ContributionHeatmap.test.tsx`、`GitHubLinkDashboard.test.tsx`）
- E2E: `npm run test:e2e`（`github-link.spec.ts` / `navigation.spec.ts` 更新）

## 影響範囲・補足

- DB マイグレーション必須（`make migrate`）。既存行は `server_default` で後方互換（全社 IT企業・資本金単位「千万円」・休暇なし扱い）
- DTO は backend `schemas/resume.py` ↔ frontend `types.ts` の手動同期運用（codegen 未導入）。`CapitalUnit` の Literal を増減する場合は両方を更新する
- 非IT企業をオンにすると、その企業配下の取引先/プロジェクトは送信対象外（`description` のみ）になる
