### PR TITLE
docs: Codex 併用のため AGENTS.md を整備（読むべきルールを明示）

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -29,7 +29,7 @@
     "docs",
     ".claude",
     "README.md",
-    "AGENT.md",
+    "AGENTS.md",
     "flake.nix",
     "Makefile"
   ],

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,1 +1,0 @@
-プロジェクトのガイドラインは [.claude/CLAUDE.md](./.claude/CLAUDE.md) を参照してください。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# DevForge - AI エージェント向けガイド（Codex 用エントリポイント）
+
+このファイルは Codex など `AGENTS.md` を読む AI エージェント向けのエントリポイント。
+Claude Code は `.claude/CLAUDE.md` を自動で読むが、**Codex は CLAUDE.md やパス連動の rule 自動ロードを行わない**ため、ここに読むべきファイルを明示する。
+
+## 最初に必ず読む
+
+- [.claude/CLAUDE.md](./.claude/CLAUDE.md) — 全体ルールの索引（実行方法・コーディング規約・コミット/PR フロー・命名・環境変数・ADR）。**作業前に必読。**
+
+## 作業領域に応じて読む（該当するものを必ず読む）
+
+Claude Code では対象パス編集時に自動ロードされる領域別ルール。Codex は自動ロードされないので、触る領域のものを手動で開くこと。
+
+### 共通（全領域）
+
+- [.claude/rules/common/duplication.md](./.claude/rules/common/duplication.md) — DRY / コード重複ポリシー（Rule of Three・抽出先ヒエラルキー）
+- [.claude/rules/security.md](./.claude/rules/security.md) — セキュリティ規約（秘密情報・入力検証・認可・IAM 等）
+
+### backend（`backend/` を触るとき）
+
+- [.claude/rules/backend/architecture.md](./.claude/rules/backend/architecture.md) — ディレクトリ構成・責務分離
+- [.claude/rules/backend/python.md](./.claude/rules/backend/python.md) — Python コーディング規約
+- [.claude/rules/backend/database.md](./.claude/rules/backend/database.md) — DB / マイグレーション
+- [.claude/rules/backend/auth-security.md](./.claude/rules/backend/auth-security.md) — 認証・認可
+- [.claude/rules/backend/llm.md](./.claude/rules/backend/llm.md) — LLM 連携
+- [.claude/rules/backend/test.md](./.claude/rules/backend/test.md) — テスト方針
+
+### frontend（`frontend/` を触るとき）
+
+- [.claude/rules/frontend/architecture.md](./.claude/rules/frontend/architecture.md) — ディレクトリ構成・責務分離
+- [.claude/rules/frontend/typescript.md](./.claude/rules/frontend/typescript.md) — TypeScript コーディング規約
+- [.claude/rules/frontend/messages.md](./.claude/rules/frontend/messages.md) — メッセージ管理（リテラル禁止・SSoT）
+- [.claude/rules/frontend/test.md](./.claude/rules/frontend/test.md) — テスト方針
+
+### infra（`infra/` を触るとき）
+
+- [.claude/rules/infra/opentofu.md](./.claude/rules/infra/opentofu.md) — OpenTofu / modules / environments
+- [.claude/rules/infra/test.md](./.claude/rules/infra/test.md) — infra validate / テスト
+
+## メンテナンス
+
+`.claude/rules/` にファイルを追加・削除したら、この一覧も更新すること（Claude Code 側はパス連動の自動ロードなので一覧不要だが、Codex 側はこの明示リストが正本）。


### PR DESCRIPTION
## 概要

Codex と Claude Code の併用を視野に、AI エージェント向けガイドのエントリポイントを整備した。

Codex は `AGENTS.md`（複数形）を読むが、Claude Code のように `CLAUDE.md` やパス連動の rule 自動ロードは行わない。そのため従来の `AGENT.md`（単数形・1行ポインタのみ）では Codex がルールを参照できない状態だった。

## 変更内容

- `AGENT.md`（単数形）→ `AGENTS.md`（Codex 標準のファイル名）にリネーム
- 中身を「最初に必ず読む（CLAUDE.md）」＋「作業領域別に読む rule ファイル一覧」の明示リストに書き換え
  - 共通 / backend / frontend / infra ごとに `.claude/rules/**` 全ファイルへのパスを列挙
  - 末尾に「rules を増減したら一覧も更新」のメンテ注記

## 補足

- Claude Code 側は `.claude/CLAUDE.md` を直接読むため挙動に影響なし
- 将来 Codex 併用の運用を見ながら改修予定（symlink 化など案A への切り替え余地あり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)