### PR TITLE
refactor: GitHub OAuth 専用化に伴う users まわりのクリーンアップ

### DIFF
--- a/.claude/rules/backend/auth-security.md
+++ b/.claude/rules/backend/auth-security.md
@@ -7,7 +7,7 @@ paths:
 
 ## 認証
 
-- **認証方式**: GitHub OAuth のみ。パスワード認証は実装していない（`User.hashed_password` は nullable のまま、OAuth 専用設計）
+- **認証方式**: GitHub OAuth のみ。パスワード認証は実装していない（`users` テーブルにパスワード関連カラムは持たない、OAuth 専用設計）
 - **JWT**: `python-jose[cryptography]`、RS256 署名（`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`）
 - **トークン有効期間**:
   - アクセストークン: 15 分（Cookie 名 `access_token`）

--- a/.claude/rules/backend/database.md
+++ b/.claude/rules/backend/database.md
@@ -9,7 +9,18 @@ paths:
 - 可変長データを JSON カラムへ増やさないこと。資格・学歴・職歴・職務経歴の明細・ブログタグは子テーブルへ正規化すること
 - 日付は可能な限り DB の `DATE` / `TIMESTAMP` を使うこと
 - `blog_articles` は `account_id` 起点で管理し、`user_id` や `platform` を冗長保持しないこと
-- マイグレーション: Alembic（`backend/alembic_migrations/versions/`）。libSQL は SQLite 互換で ALTER COLUMN 非対応のため `batch_alter_table` を使うこと
+- マイグレーション: Alembic（`backend/alembic_migrations/versions/`）。詳細は下記「マイグレーション運用」を参照
+
+## マイグレーション運用
+
+- **ADD COLUMN**: libSQL は `ALTER TABLE ADD COLUMN` を直接サポートするので `op.add_column` をそのまま使う
+- **ALTER COLUMN（型・制約変更）**: libSQL は非対応。`batch_alter_table`（テーブル再作成）で行う
+- **DROP COLUMN は原則 `op.drop_column` を直接使う**: SQLite/libSQL 3.35+ は `ALTER TABLE ... DROP COLUMN` をサポートする。インデックス・FK・制約のない素のカラムはこれで消せる（テーブル再作成不要）
+- **FK 参照される親テーブルに `batch_alter_table` を使わない**: batch は「新テーブル作成 → 旧テーブル DROP → リネーム」で動くため、`users` のように子テーブルから FK 参照される親を batch で触ると、旧テーブル DROP 時に libSQL（`foreign_keys=ON`）で `FOREIGN KEY constraint failed` になる。標準 SQLite ドライバは `foreign_keys` がデフォルト OFF で通ってしまい差異を見落とすので注意。子テーブル（他から参照されない）の `drop_column` でのみ batch は安全
+- **マイグレーションは `make test-backend` では検証されない**: テストは `conftest.py` の `Base.metadata.create_all` でスキーマを作るため alembic を通らない。migration の upgrade/downgrade は **実 libSQL に対して**確認すること:
+  - offline SQL の事前確認: `nix develop --command bash -c "cd backend && TURSO_DATABASE_URL='file:///tmp/x.db' .venv/bin/python -m alembic upgrade <from>:<to> --sql"`
+  - 実適用: docker stack を起動（`make dev-build`）し `docker compose logs api` で適用成功を確認する
+- 失敗した `batch_alter_table` が残す `_alembic_tmp_<table>` テーブルは `turso db shell http://localhost:8080 "DROP TABLE IF EXISTS _alembic_tmp_<table>"` で掃除する
 
 ## Turso (libSQL) 接続方式
 

--- a/backend/alembic_migrations/versions/0041_drop_github_username_prefix.py
+++ b/backend/alembic_migrations/versions/0041_drop_github_username_prefix.py
@@ -1,0 +1,44 @@
+"""username の "github:" プレフィックスを廃止する
+
+本プロダクトは GitHub ログイン専用のため、username の "github:" 名前空間
+プレフィックスは不要。新規保存では付与をやめ、既存行も素の login 名へ書き換える。
+GitHub ユーザー判定は username ではなく github_id (unique) で行うよう変更済み。
+
+スキーマ変更はなくデータのみの書き換え。
+
+Revision ID: 0041_drop_github_username_prefix
+Revises: 0040_add_resume_non_it_and_vacation
+Create Date: 2026-06-01 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041_drop_github_username_prefix"
+down_revision: Union[str, None] = "0040_add_resume_non_it_and_vacation"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # "github:" は 7 文字。SQLite SUBSTR は 1 始まりなので 8 文字目以降が素の login 名。
+    conn.execute(
+        sa.text(
+            "UPDATE users SET username = SUBSTR(username, 8) "
+            "WHERE username LIKE 'github:%'"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # GitHub ユーザー（github_id あり）のみプレフィックスを復元する。
+    conn.execute(
+        sa.text(
+            "UPDATE users SET username = 'github:' || username "
+            "WHERE github_id IS NOT NULL AND username NOT LIKE 'github:%'"
+        )
+    )

--- a/backend/alembic_migrations/versions/0042_drop_users_hashed_password.py
+++ b/backend/alembic_migrations/versions/0042_drop_users_hashed_password.py
@@ -1,0 +1,37 @@
+"""users.hashed_password カラムを撤去する
+
+本プロダクトは GitHub OAuth 専用でパスワード認証を実装しておらず、
+hashed_password は常に NULL のまま読み取られないデッドカラムだった。
+保持コストと将来の誤用を避けるためカラムごと削除する。
+
+hashed_password はインデックス・FK・制約のない素のカラムのため、テーブル再作成を
+伴わない直接の DROP COLUMN（SQLite/libSQL 3.35+ がサポート）で削除する。
+batch_alter_table は users（多数の子テーブルから FK 参照される親）を一旦 DROP する
+ため、libSQL の foreign_keys=ON 環境で FOREIGN KEY 制約違反になり使えない。
+downgrade は元の nullable カラムを復元する（ADD COLUMN は libSQL も直接サポート）。
+
+Revision ID: 0042_drop_users_hashed_password
+Revises: 0041_drop_github_username_prefix
+Create Date: 2026-06-01 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0042_drop_users_hashed_password"
+down_revision: Union[str, None] = "0041_drop_github_username_prefix"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("users", "hashed_password")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("hashed_password", sa.String(length=255), nullable=True),
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -12,7 +12,6 @@ class User(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     username: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
-    hashed_password: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)
     email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True, default=None)
     github_id: Mapped[int | None] = mapped_column(nullable=True, unique=True, default=None)
     github_token: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -7,8 +7,8 @@ class UserRepository:
     def __init__(self, db):
         self.db = db
 
-    def create(self, username: str, hashed_password: str | None = None, email: str | None = None) -> User:
-        user = User(username=username, hashed_password=hashed_password, email=email)
+    def create(self, username: str, email: str | None = None) -> User:
+        user = User(username=username, email=email)
         self.db.add(user)
         self.db.commit()
         self.db.refresh(user)
@@ -24,7 +24,7 @@ class UserRepository:
         return self.db.scalar(select(User).where(User.github_id == github_id))
 
     def create_github_user(self, username: str, github_id: int) -> User:
-        user = User(username=username, hashed_password=None, github_id=github_id)
+        user = User(username=username, github_id=github_id)
         self.db.add(user)
         self.db.commit()
         self.db.refresh(user)

--- a/backend/app/routers/auth/endpoints.py
+++ b/backend/app/routers/auth/endpoints.py
@@ -104,7 +104,7 @@ def refresh(
     set_auth_cookies(response, user.username, db)
     return TokenResponse(
         username=user.username,
-        is_github_user=user.username.startswith("github:"),
+        is_github_user=user.github_id is not None,
     )
 
 
@@ -138,7 +138,7 @@ def me(request: Request, current_user=Depends(get_current_user)) -> TokenRespons
     """現在のログインユーザー情報を返す。"""
     return TokenResponse(
         username=current_user.username,
-        is_github_user=current_user.username.startswith("github:"),
+        is_github_user=current_user.github_id is not None,
     )
 
 

--- a/backend/app/routers/auth/github_auth.py
+++ b/backend/app/routers/auth/github_auth.py
@@ -95,7 +95,7 @@ async def authenticate_github_user(
     user = repo.get_by_github_id(github_id)
     if not user:
         user = repo.create_github_user(
-            username=f"github:{github_login}",
+            username=github_login,
             github_id=github_id,
         )
         log_event(logging.INFO, "github_user_created", username=user.username)

--- a/backend/app/routers/github_link.py
+++ b/backend/app/routers/github_link.py
@@ -108,7 +108,7 @@ async def start_github_link(
     db: Session = Depends(get_db),
 ):
     """GitHub 連携パイプラインをバックグラウンドで開始する。"""
-    if not user.username.startswith("github:"):
+    if user.github_id is None:
         raise_app_error(
             status_code=403,
             code=ErrorCode.AUTH_REQUIRED,
@@ -116,7 +116,7 @@ async def start_github_link(
             action="GitHub アカウントでログインし直してください",
         )
 
-    github_username = user.username.removeprefix("github:")
+    github_username = user.username
 
     # 進行中のタスクがあればそのステータスを返す
     cache = _get_or_create_cache(db, user.id)
@@ -159,7 +159,7 @@ async def retry_github_link(
     ``dead_letter`` 状態のキャッシュのみ再実行可能。
     ``retry_count`` を 0 にリセットし、ステータスを ``pending`` に戻して再ディスパッチする。
     """
-    if not user.username.startswith("github:"):
+    if user.github_id is None:
         raise_app_error(
             status_code=403,
             code=ErrorCode.AUTH_REQUIRED,
@@ -184,7 +184,7 @@ async def retry_github_link(
             action="タスクの完了または失敗を待ってから再試行してください",
         )
 
-    github_username = user.username.removeprefix("github:")
+    github_username = user.username
     include_forks = payload.include_forks if payload else False
 
     # DB 最新状態を取得しつつアトミック遷移。並列リトライ競合を防ぐ

--- a/backend/tests/auth/test_oauth_flow.py
+++ b/backend/tests/auth/test_oauth_flow.py
@@ -295,7 +295,9 @@ def test_github_callback_post_does_not_require_cookie(client) -> None:
         )
 
     assert response.status_code == 200
-    assert response.json()["username"] == "github:octo-post"
+    # username に "github:" プレフィックスを付けない（素の login 名で保存する）
+    assert response.json()["username"] == "octo-post"
+    assert response.json()["is_github_user"] is True
     assert "access_token=" in response.headers["set-cookie"]
     # GitHub への redirect_uri も /github/callback でトークン交換していることを確認する
     posted_kwargs = mock_http.post.call_args.kwargs

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -204,16 +204,19 @@ def make_resume_payload(**overrides) -> dict:
     return payload
 
 
-def auth_header(client, username: str = "testuser") -> dict:
+def auth_header(client, username: str = "testuser", *, github_id: int | None = None) -> dict:
     """テスト用の認証 Cookie をセットするヘルパー。CSRF トークンをヘッダーに含む dict を返す。
 
     DB にユーザーを直接作成し、JWT Cookie をセットする。
     /auth/register や /auth/login エンドポイントには依存しない。
+
+    GitHub 連携を要するエンドポイント（github_id ベースのガード）をテストする場合は
+    ``github_id`` を渡して GitHub ユーザーとして作成する。
     """
     db = client._db_session
     repo = UserRepository(db)
     if not repo.get_by_username(username):
-        repo.create(username, hashed_password=None, email=f"{username}@example.com")
+        repo.create(username, email=f"{username}@example.com")
 
     access_token = create_access_token(username)
     refresh_token, jti = create_refresh_token(username)
@@ -223,6 +226,8 @@ def auth_header(client, username: str = "testuser") -> dict:
     user = repo.get_by_username(username)
     if user:
         user.refresh_jti = jti
+        if github_id is not None:
+            user.github_id = github_id
         db.commit()
 
     session_payload = json.dumps({"access_token": access_token, "refresh_token": refresh_token})

--- a/backend/tests/security/_helpers.py
+++ b/backend/tests/security/_helpers.py
@@ -46,5 +46,5 @@ def ensure_user(db, username: str) -> User:
     repo = UserRepository(db)
     user = repo.get_by_username(username)
     if not user:
-        user = repo.create(username, hashed_password=None, email=f"{username}@example.com")
+        user = repo.create(username, email=f"{username}@example.com")
     return user

--- a/backend/tests/security/test_mass_assignment.py
+++ b/backend/tests/security/test_mass_assignment.py
@@ -18,7 +18,7 @@ _SERVICE_VERIFY_PATCH = "app.services.blog.account_service.verify_user_exists"
 def test_resume_create_does_not_transfer_ownership(client: TestClient) -> None:
     """POST /api/resumes に他人の user_id を混ぜても、その他人は所有者にならない。"""
     db = client._db_session
-    UserRepository(db).create("victim-a", hashed_password=None, email="victim-a@example.com")
+    UserRepository(db).create("victim-a", email="victim-a@example.com")
     victim = UserRepository(db).get_by_username("victim-a")
 
     headers = auth_header(client, "attacker-a")
@@ -39,7 +39,7 @@ def test_resume_create_does_not_transfer_ownership(client: TestClient) -> None:
 def test_resume_update_does_not_transfer_ownership(client: TestClient) -> None:
     """PUT /api/resumes/{id} に他人の user_id を混ぜても所有者が移らない。"""
     db = client._db_session
-    UserRepository(db).create("victim-b", hashed_password=None, email="victim-b@example.com")
+    UserRepository(db).create("victim-b", email="victim-b@example.com")
     victim = UserRepository(db).get_by_username("victim-b")
 
     headers = auth_header(client, "attacker-b")
@@ -65,7 +65,7 @@ def test_resume_update_does_not_transfer_ownership(client: TestClient) -> None:
 def test_blog_account_create_does_not_transfer_ownership(client: TestClient) -> None:
     """POST /api/blog/accounts に他人の user_id を混ぜても、その他人は所有者にならない。"""
     db = client._db_session
-    UserRepository(db).create("victim-blog-a", hashed_password=None, email="victim-blog-a@example.com")
+    UserRepository(db).create("victim-blog-a", email="victim-blog-a@example.com")
     victim = UserRepository(db).get_by_username("victim-blog-a")
 
     headers = auth_header(client, "attacker-blog-a")
@@ -89,7 +89,7 @@ def test_blog_account_create_does_not_transfer_ownership(client: TestClient) -> 
 def test_blog_account_update_does_not_transfer_ownership(client: TestClient) -> None:
     """PATCH /api/blog/accounts/{platform} に他人の user_id を混ぜても所有者が移らない。"""
     db = client._db_session
-    UserRepository(db).create("victim-blog-b", hashed_password=None, email="victim-blog-b@example.com")
+    UserRepository(db).create("victim-blog-b", email="victim-blog-b@example.com")
     victim = UserRepository(db).get_by_username("victim-blog-b")
 
     headers = auth_header(client, "attacker-blog-b")

--- a/backend/tests/services/tasks/test_handlers_failure.py
+++ b/backend/tests/services/tasks/test_handlers_failure.py
@@ -36,7 +36,6 @@ def _make_user(db: Session, username: str):
     """テスト用ユーザーを作成する。"""
     return UserRepository(db).create(
         username,
-        hashed_password=None,
         email=f"{username}@test.com",
     )
 

--- a/backend/tests/test_retry_flow.py
+++ b/backend/tests/test_retry_flow.py
@@ -343,8 +343,6 @@ class TestRetryEndpoints:
         assert cache.status == "pending"
         assert cache.retry_count == 0
         assert cache.error_message is None
-        assert cache.retry_count == 0
-        assert cache.error_message is None
 
     def test_retry_returns_404_when_no_cache(self, client: TestClient):
         """連携キャッシュが未作成なら 404（先に連携を実行させる）。"""

--- a/backend/tests/test_retry_flow.py
+++ b/backend/tests/test_retry_flow.py
@@ -73,7 +73,7 @@ def _setup_github_link_test(
     yield する mock_notify で `_create_notification` の呼び出し有無を検証できる。
     """
     user = UserRepository(db_session).create(
-        f"github:{suffix}", hashed_password=None, email=f"{suffix}@test.com",
+        suffix, email=f"{suffix}@test.com",
     )
     cache = GitHubLinkCache(user_id=user.id, status=initial_status)
     db_session.add(cache)
@@ -316,15 +316,15 @@ class TestRetryEndpoints:
     """`POST /{resource}/retry` が失敗状態をリセットし再ディスパッチすること。"""
 
     def test_intelligence_retry_requires_github_user(self, client: TestClient):
-        """GitHub 以外のユーザーは GitHub 連携リトライを実行できない。"""
+        """github_id を持たないユーザーは GitHub 連携リトライを実行できない。"""
         headers = auth_header(client, "non-github-user")
         resp = client.post("/api/github-link/run/retry", headers=headers)
         assert resp.status_code == 403
 
     def test_intelligence_retry_resets_cache(self, client: TestClient):
-        headers = auth_header(client, "github:retry-intel-user")
+        headers = auth_header(client, "retry-intel-user", github_id=999)
         db = client._db_session
-        user = UserRepository(db).get_by_username("github:retry-intel-user")
+        user = UserRepository(db).get_by_username("retry-intel-user")
 
         cache = GitHubLinkCache(
             user_id=user.id,
@@ -348,15 +348,15 @@ class TestRetryEndpoints:
 
     def test_retry_returns_404_when_no_cache(self, client: TestClient):
         """連携キャッシュが未作成なら 404（先に連携を実行させる）。"""
-        headers = auth_header(client, "github:retry-nocache-user")
+        headers = auth_header(client, "retry-nocache-user", github_id=999)
         resp = client.post("/api/github-link/run/retry", headers=headers)
         assert resp.status_code == 404
 
     @pytest.mark.parametrize("status", ["completed", "processing", "pending", "retrying"])
     def test_retry_returns_409_when_not_dead_letter(self, client: TestClient, status: str):
         """dead_letter 以外（completed / processing 等）の状態では再実行できず 409。"""
-        username = f"github:retry-409-{status}"
-        headers = auth_header(client, username)
+        username = f"retry-409-{status}"
+        headers = auth_header(client, username, github_id=999)
         db = client._db_session
         user = UserRepository(db).get_by_username(username)
 
@@ -374,9 +374,9 @@ class TestRetryEndpoints:
     def test_retry_returns_409_on_concurrent_reset_race(self, client: TestClient):
         """is_retryable_terminal は通過しても、並列競合で try_reset_to_pending が
         False を返したら 409 にすること（TOCTOU ガード）。"""
-        headers = auth_header(client, "github:retry-race-user")
+        headers = auth_header(client, "retry-race-user", github_id=999)
         db = client._db_session
-        user = UserRepository(db).get_by_username("github:retry-race-user")
+        user = UserRepository(db).get_by_username("retry-race-user")
 
         cache = GitHubLinkCache(user_id=user.id, status="dead_letter", retry_count=2)
         db.add(cache)
@@ -401,7 +401,7 @@ def test_is_final_at_last_attempt(db_session: Session):
     # この境界条件は TestExecuteTaskRetryBranching.test_retryable_error_on_final_attempt
     # で既にカバーしているが、ここで明示的にパラメトリックに確認する。
     user = UserRepository(db_session).create(
-        "github:boundary-user", hashed_password=None, email="boundary@test.com",
+        "boundary-user", email="boundary@test.com",
     )
     cache = GitHubLinkCache(user_id=user.id, status="processing")
     db_session.add(cache)

--- a/backend/tests/test_worker/test_execute_task.py
+++ b/backend/tests/test_worker/test_execute_task.py
@@ -61,7 +61,7 @@ class TestExecuteTask:
         内部関数 _mark_dead_letter の呼び出し引数ではなく結果 DB state を検証する
         （test_retry_flow.py と同じ契約を、実装詳細に結合しない形で守る）。"""
         user = UserRepository(db_session).create(
-            "github:dead-letter-user", hashed_password=None, email="dl@test.com",
+            "dead-letter-user", email="dl@test.com",
         )
         cache = GitHubLinkCache(user_id=user.id, status="processing")
         db_session.add(cache)
@@ -129,7 +129,7 @@ class TestSafeRollback:
         テストとして空回りしていた。
         """
         user = UserRepository(db_session).create(
-            "rollback-test-user", hashed_password=None, email="rollback@test.com"
+            "rollback-test-user", email="rollback@test.com"
         )
         first_cache = GitHubLinkCache(user_id=user.id, status="processing")
         db_session.add(first_cache)

--- a/backend/tests/test_worker/test_github_link.py
+++ b/backend/tests/test_worker/test_github_link.py
@@ -12,10 +12,9 @@ from ._helpers import run_sync as _run
 
 
 class TestRunGithubAnalysis:
-    def _make_user_and_cache(self, db: Session, username="github:gh-user"):
+    def _make_user_and_cache(self, db: Session, username="gh-user"):
         user = UserRepository(db).create(
             username,
-            hashed_password=None,
             email=f"{username}@test.com",
         )
         cache = GitHubLinkCache(user_id=user.id, status="pending")
@@ -95,7 +94,7 @@ class TestRunGithubAnalysis:
         そのまま永続化され、error/warning がクリアされること（内容まで検証）。"""
         from app.schemas.github_link import ContributionCalendar, ContributionDay
 
-        user, cache = self._make_user_and_cache(db_session, "github:content-user")
+        user, cache = self._make_user_and_cache(db_session, "content-user")
         # 前回失敗の痕跡が成功時にクリアされることも併せて確認する
         cache.error_message = "前回の失敗"
         cache.warning_message = "前回の警告"
@@ -169,7 +168,7 @@ class TestRunGithubAnalysis:
         warning_message が立たないこと。"""
         from app.schemas.github_link import ContributionCalendar, ContributionDay
 
-        user, cache = self._make_user_and_cache(db_session, "github:calendar-user")
+        user, cache = self._make_user_and_cache(db_session, "calendar-user")
         repos = self._sample_repos()
         calendar = ContributionCalendar(
             total_contributions=7,
@@ -217,7 +216,7 @@ class TestRunGithubAnalysis:
     ):
         """コントリビューション取得失敗（None）でも連携は completed のままで、
         warning_message が立つこと。"""
-        user, cache = self._make_user_and_cache(db_session, "github:warn-user")
+        user, cache = self._make_user_and_cache(db_session, "warn-user")
         repos = self._sample_repos()
 
         with (
@@ -301,7 +300,7 @@ class TestRunGithubAnalysis:
         """GitHubUserNotFoundError 発生時に status が dead_letter になること。"""
         from app.services.intelligence.github.api_client import GitHubUserNotFoundError
 
-        user, cache = self._make_user_and_cache(db_session, "github:notfound")
+        user, cache = self._make_user_and_cache(db_session, "notfound")
 
         with (
             patch(

--- a/backend/tests/test_worker_timeout.py
+++ b/backend/tests/test_worker_timeout.py
@@ -28,8 +28,7 @@ def _run(coro):
 def test_github_link_timeout_propagates(db_session: Session, session_factory) -> None:
     """collect_repos で asyncio.TimeoutError が発生した場合に例外が伝播することを確認する。"""
     user = UserRepository(db_session).create(
-        "github:timeout-user",
-        hashed_password=None,
+        "timeout-user",
         email="timeout@example.com",
     )
     cache = GitHubLinkCache(user_id=user.id, status="pending")

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 
 /** テスト用認証済みユーザー情報 */
 export const TEST_USER = {
-  username: "github:e2e-test-user",
+  username: "e2e-test-user",
   is_github_user: true,
 };
 

--- a/frontend/src/components/UserMenu.module.css
+++ b/frontend/src/components/UserMenu.module.css
@@ -96,7 +96,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/frontend/src/components/UserMenu.module.css
+++ b/frontend/src/components/UserMenu.module.css
@@ -52,15 +52,6 @@
   z-index: 200;
 }
 
-.menuUsername {
-  padding: 0.5rem 0.6rem 0.4rem;
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.45);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .menuItem {
   display: flex;
   align-items: center;
@@ -91,6 +82,13 @@
   height: 1px;
   background: rgba(255, 255, 255, 0.08);
   margin: 0.25rem 0.4rem;
+}
+
+.menuFooter {
+  padding: 0.4rem 0.6rem 0.3rem;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.35);
+  text-align: center;
 }
 
 /* Toggle switch */

--- a/frontend/src/components/UserMenu.module.css
+++ b/frontend/src/components/UserMenu.module.css
@@ -78,6 +78,29 @@
   flex: 1;
 }
 
+.externalIcon {
+  flex-shrink: 0;
+  margin-left: 0.4rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.menuItem:hover .externalIcon {
+  color: #fff;
+}
+
+/* スクリーンリーダー専用テキスト（視覚的には非表示） */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .separator {
   height: 1px;
   background: rgba(255, 255, 255, 0.08);

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -58,6 +58,24 @@ export function UserMenu({
             onClick={() => setOpen(false)}
           >
             <span className={styles.menuItemLabel}>{UI_MESSAGES.REPORT_ISSUE}</span>
+            <svg
+              className={styles.externalIcon}
+              viewBox="0 0 24 24"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+            <span className={styles.srOnly}>{UI_MESSAGES.OPENS_IN_NEW_TAB}</span>
           </a>
           <div className={styles.menuFooter}>{UI_MESSAGES.COPYRIGHT}</div>
         </div>

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { EXTERNAL_LINKS, UI_MESSAGES } from "../constants/messages";
 import type { Theme } from "../hooks/useTheme";
 import styles from "./UserMenu.module.css";
 
@@ -34,7 +35,6 @@ export function UserMenu({
     <div className={styles.wrapper} ref={ref}>
       {open && (
         <div className={styles.menu}>
-          {username && <div className={styles.menuUsername}>{username}</div>}
           <button type="button" className={styles.menuItem} onClick={onToggleTheme}>
             <span className={styles.menuItemLabel}>ダークモード</span>
             <span className={`${styles.toggle} ${isDark ? styles.toggleOn : ""}`}>
@@ -49,6 +49,17 @@ export function UserMenu({
           >
             <span className={styles.menuItemLabel}>ログアウト</span>
           </button>
+          <div className={styles.separator} />
+          <a
+            className={styles.menuItem}
+            href={EXTERNAL_LINKS.ISSUE_REPORT}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+          >
+            <span className={styles.menuItemLabel}>{UI_MESSAGES.REPORT_ISSUE}</span>
+          </a>
+          <div className={styles.menuFooter}>{UI_MESSAGES.COPYRIGHT}</div>
         </div>
       )}
       <button

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -88,6 +88,7 @@ export const UI_MESSAGES = {
   SOURCE_PANEL_COLLAPSE: "原本パネルを閉じる",
   SOURCE_PANEL_EXPAND: "原本パネルを開く",
   REPORT_ISSUE: "GitHub Issueに報告",
+  OPENS_IN_NEW_TAB: "（新しいタブで開きます）",
   COPYRIGHT: "© 2026 DevForge",
 } as const;
 

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -87,6 +87,13 @@ export const UI_MESSAGES = {
   SIDEBAR_EXPAND: "サイドバーを開く",
   SOURCE_PANEL_COLLAPSE: "原本パネルを閉じる",
   SOURCE_PANEL_EXPAND: "原本パネルを開く",
+  REPORT_ISSUE: "GitHub Issueに報告",
+  COPYRIGHT: "© 2026 DevForge",
+} as const;
+
+/** 外部リンク URL（GitHub リポジトリ / Issue 報告先など）の SSoT */
+export const EXTERNAL_LINKS = {
+  ISSUE_REPORT: "https://github.com/yusuke0610/devforge/issues",
 } as const;
 
 /** ファイル取り込み補助（PDF / Markdown 原本上の選択 → 流し込み）UI の文言 */


### PR DESCRIPTION
## 概要

GitHub OAuth 専用設計に合わせて `users` まわりの不要・冗長な要素を撤去するクリーンアップ。2つの独立したスキーマ変更を含みます。

## 変更内容

### (A) username の `github:` プレフィックス廃止（migration 0041）
- GitHub ユーザー判定を username ではなく `github_id`（unique）で行う方針に統一
- `UserMenu` / 関連メッセージ / 認証・GitHub 連携経路を素の login 名前提に更新
- 既存行の `github:` プレフィックスはデータ書き換えで除去

### (B) 未使用の `users.hashed_password` カラム撤去（migration 0042）
- パスワード認証は未実装で、当カラムは常に NULL のまま読み取られないデッドカラムだった
- `batch_alter_table` は `users`（多数の子テーブルから FK 参照される親）を一旦 DROP するため libSQL の `foreign_keys=ON` 環境で FK 制約違反になる。インデックス・FK・制約のない素のカラムのため、テーブル再作成を伴わない**直接 `DROP COLUMN`** で適用
- `.claude/rules/backend/{auth-security,database}.md` を実態に合わせて更新

## マイグレーション適用

両 migration はデプロイ時にコンテナ起動（`entrypoint.sh` → `bootstrap` → `alembic upgrade head`）で各環境の Turso Cloud DB に自動適用される。手動 SQL は不要。

## 検証

- `make ci`: backend lint/test・frontend lint/vitest(205)・build すべて pass
- 実 libSQL（docker stack）に対して migration 0041→0042 の適用成功を確認
- E2E: 27 件すべて pass（認証・ナビゲーション・UserMenu 含む）

## 注意

- **破壊的変更（DB スキーマ × 2）**: 0041 はデータ書き換え、0042 はカラム削除。どちらも本番では起動時自動適用
- `make test-backend` は `create_all` でスキーマを作るため migration を検証しない点に注意（libSQL 実適用で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an external issue-report link and copyright footer in the user menu.

* **Bug Fixes**
  * GitHub users are now detected reliably by stored GitHub ID rather than username prefix.
  * Displayed GitHub usernames no longer include the legacy "github:" prefix.

* **Chores**
  * Removed legacy unused password column and updated migration/DB operation guidance.

* **Tests**
  * Updated tests and helpers to use plain GitHub usernames and reflect auth behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->