### PR TITLE
職務経歴書PDFの余白修正とフォーム・出力表記の調整

### DIFF
--- a/backend/app/services/markdown/generators/resume_generator.py
+++ b/backend/app/services/markdown/generators/resume_generator.py
@@ -144,7 +144,7 @@ def build_resume_markdown(payload: dict[str, Any]) -> str:
                             f"{CATEGORY_LABELS.get(c, c)}: {', '.join(ns)}"
                             for c, ns in grouped.items()
                         ]
-                        lines.append(field_line("技術スタック", " / ".join(parts)))
+                        lines.append(field_line("スキルセット", " / ".join(parts)))
                     lines.append("")
 
     self_pr = payload.get("self_pr", "")

--- a/backend/app/services/pdf/generators/resume_generator.py
+++ b/backend/app/services/pdf/generators/resume_generator.py
@@ -54,6 +54,24 @@ def _format_periods(periods: list) -> str:
     return "、".join(parts)
 
 
+def _format_team(project) -> str:
+    """体制の人数情報を「6名（PM：1名、SE：6名）」形式の1行文字列にする。
+
+    後方互換（旧 scale → team）の正規化は shared に集約。情報が無ければ空文字を返す。
+    """
+    team = normalize_team(project)
+    if not team:
+        return ""
+    total = _a(team, "total")
+    total_text = f"{_esc(total)}名" if total else ""
+    members = _a(team, "members", [])
+    member_strs = [
+        f"{_esc(_a(m, 'role'))}：{_esc(_a(m, 'count', 0))}名" for m in members if _a(m, "role")
+    ]
+    member_text = f"（{'、'.join(member_strs)}）" if member_strs else ""
+    return f"{total_text}{member_text}"
+
+
 def _build_project_html(project) -> str:
     """プロジェクト1件分のHTMLを組み立てる"""
     # ヘッダー（3行構成: 期間/プロジェクト名、役割、工程）
@@ -71,8 +89,11 @@ def _build_project_html(project) -> str:
         line1_parts.append(_esc(name))
     line1 = "　／　".join(line1_parts) if line1_parts else ""
 
-    # 2行目: 役割
-    line2 = f"役割：{_esc(role)}" if role else ""
+    # 2行目: 役割（体制の人数情報を「、体制：…」として役割の右側に併記する）
+    team_text = _format_team(project)
+    role_part = f"役割：{_esc(role)}" if role else ""
+    team_part = f"体制：{team_text}" if team_text else ""
+    line2 = "、".join(p for p in [role_part, team_part] if p)
 
     # 3行目: 工程
     line3 = ""
@@ -91,7 +112,7 @@ def _build_project_html(project) -> str:
         left_parts.append(_md(description))
     left_content = "".join(left_parts) if left_parts else "-"
 
-    # 右カラム: 開発環境（技術スタック）
+    # 右カラム: スキルセット（技術スタックのカテゴリ別表示）
     stacks = _a(project, "technology_stacks", [])
     grouped = group_stacks_by_category(stacks)
     right_parts: list[str] = []
@@ -102,28 +123,13 @@ def _build_project_html(project) -> str:
         )
     right_content = "<br/>".join(right_parts) if right_parts else "-"
 
-    # 体制（後方互換: 旧 scale → team の正規化は shared に集約）
-    team = normalize_team(project)
-    team_parts: list[str] = []
-    if team:
-        total = _a(team, "total")
-        if total:
-            team_parts.append(f"{_esc(total)}名")
-        members = _a(team, "members", [])
-        member_strs = [
-            f"{_esc(_a(m, 'role'))}:{_a(m, 'count', 0)}" for m in members if _a(m, "role")
-        ]
-        if member_strs:
-            team_parts.append(" / ".join(member_strs))
-    team_text = "<br/>".join(team_parts) if team_parts else "-"
-
+    # 体制は表のカラムではなく役割行に併記する（line2 で処理済み）。
     return (
         f'<div class="project">{header_html}'
         f'<table class="project-table">'
-        f"<tr><th>業務内容</th><th>開発環境</th><th>体制</th></tr>"
-        f'<tr><td class="desc">{left_content}</td>'
-        f'<td class="env">{right_content}</td>'
-        f'<td class="team">{team_text}</td></tr>'
+        f"<thead><tr><th>業務内容</th><th>スキルセット</th></tr></thead>"
+        f'<tbody><tr><td class="desc">{left_content}</td>'
+        f'<td class="env">{right_content}</td></tr></tbody>'
         f"</table></div>"
     )
 
@@ -223,7 +229,7 @@ def _build_html(resume: dict) -> str:
                     client_name = _a(client, "name")
                     if client_name:
                         parts.append(
-                            f'<div class="client-name">' f"取引先名：{_esc(client_name)}</div>",
+                            f'<div class="client-name">' f"案件名：{_esc(client_name)}</div>",
                         )
                     projects = _a(client, "projects", [])
                     for proj in projects:

--- a/backend/app/services/pdf/templates/resume.css
+++ b/backend/app/services/pdf/templates/resume.css
@@ -39,13 +39,17 @@ h2 {
   border-bottom: 2px solid #333;
   padding-bottom: 1mm;
   margin: 6mm 0 3mm 0;
+  /* 見出しがページ末尾に孤立して直後の本文だけ次ページに行くのを防ぐ */
+  page-break-after: avoid;
 }
 
 /* 会社ブロック */
 .company {
   border: 0.5px solid #666;
   margin-bottom: 3mm;
-  page-break-inside: avoid;
+  /* 会社ブロック全体を 1 ページに固めると、収まらない時に丸ごと次ページへ送られ、
+     直前（職務要約など）に大きな空白が残る。ページ跨ぎを許可してページを詰める。
+     代わりに分割を避けるのは下位の .project 単位で行う。 */
 }
 
 .company-header {
@@ -54,6 +58,8 @@ h2 {
   font-size: 10pt;
   font-weight: bold;
   border-bottom: 0.3px solid #999;
+  /* ヘッダがページ末尾に孤立し本文だけ次ページに分かれるのを防ぐ */
+  page-break-after: avoid;
 }
 
 .company-info {
@@ -104,11 +110,16 @@ h2 {
   margin: 3mm 0 2mm 0;
   padding-bottom: 1mm;
   border-bottom: 2px solid #333;
+  /* 取引先名見出しの孤立防止 */
+  page-break-after: avoid;
 }
 
 /* プロジェクトテーブル */
 .project {
   margin-bottom: 2mm;
+  /* 1 案件（ヘッダ＋テーブル）は途中で割らず可読性を保つ。
+     会社ブロックはページ跨ぎ可、分割回避はこの単位で行う。 */
+  page-break-inside: avoid;
 }
 
 .project-header {

--- a/backend/app/services/pdf/templates/resume.css
+++ b/backend/app/services/pdf/templates/resume.css
@@ -14,6 +14,7 @@
 }
 
 body {
+  margin: 0;
   font-family: "NotoSansJP", sans-serif;
   font-size: 9pt;
   line-height: 1.6;
@@ -110,16 +111,17 @@ h2 {
   margin: 3mm 0 2mm 0;
   padding-bottom: 1mm;
   border-bottom: 2px solid #333;
-  /* 取引先名見出しの孤立防止 */
+  /* 案件名見出しの孤立防止 */
   page-break-after: avoid;
 }
 
 /* プロジェクトテーブル */
 .project {
   margin-bottom: 2mm;
-  /* 1 案件（ヘッダ＋テーブル）は途中で割らず可読性を保つ。
-     会社ブロックはページ跨ぎ可、分割回避はこの単位で行う。 */
-  page-break-inside: avoid;
+  /* 案件が残りスペースに収まらない時に丸ごと次ページへ送られると、
+     枠付き company 内に大きな余白が残る。ページを詰めるため分割を許可する
+     （長い案件はページ境界で割れるが、余白を残すより詰めることを優先）。
+     分割時の列見出しは project-table の thead で繰り返す。 */
 }
 
 .project-header {
@@ -150,15 +152,12 @@ h2 {
 }
 
 .project-table td.desc {
-  width: 60%;
+  /* 体制カラムを廃止した分を業務内容へ割り当てる */
+  width: 75%;
 }
 
 .project-table td.env {
   width: 25%;
-}
-
-.project-table td.team {
-  width: 15%;
 }
 
 /* 業務内容カラム内のラベル */

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6807,9 +6807,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6829,12 +6829,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
@@ -116,7 +116,7 @@ export function CareerExperienceEditor({
               placeholder="例: SES事業、受託開発"
             />
           </label>
-          {/* IT企業かどうか（非ITは取引先を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
+          {/* IT企業かどうか（非ITは案件を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
               上段は labelText のスペーサで隣のラベル行と高さを合わせ、下段のトグルを入力欄と横並びにする。 */}
           <label>
             <span className={shared.labelText} aria-hidden="true">

--- a/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
@@ -85,7 +85,8 @@ export function CareerExperienceEditor({
           </>
         }
       >
-        <div className={shared.inline}>
+        {/* 会社名:事業内容:IT企業 = 4.5:5:0.5 の幅比で配置 */}
+        <div className={shared.inline} style={{ gridTemplateColumns: "4.5fr 5fr 0.5fr" }}>
           <label>
             {/* グローバル CSS で label { display: grid } のため、テキストと DirtyDot を span で
               束ねないと別々の行になる。span で 1 グリッド行に束ねることでラベル右側に並べる。 */}
@@ -114,6 +115,26 @@ export function CareerExperienceEditor({
               }
               placeholder="例: SES事業、受託開発"
             />
+          </label>
+          {/* IT企業かどうか（非ITは取引先を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
+              上段は labelText のスペーサで隣のラベル行と高さを合わせ、下段のトグルを入力欄と横並びにする。 */}
+          <label>
+            <span className={shared.labelText} aria-hidden="true">
+              &nbsp;
+            </span>
+            <span className={styles.companyTypeToggle}>
+              <input
+                type="checkbox"
+                checked={exp.is_it_company}
+                onChange={(e) =>
+                  onUpdateExperienceField(expIndex, "is_it_company", e.target.checked)
+                }
+              />
+              <span>
+                IT企業
+                <DirtyDot visible={Boolean(fieldDirty?.is_it_company)} />
+              </span>
+            </span>
           </label>
         </div>
 
@@ -215,19 +236,6 @@ export function CareerExperienceEditor({
           </label>
         </div>
 
-        {/* IT企業かどうか（非ITは取引先を持たず詳細のみ） */}
-        <label className={styles.clientCheckbox}>
-          <input
-            type="checkbox"
-            checked={exp.is_it_company}
-            onChange={(e) => onUpdateExperienceField(expIndex, "is_it_company", e.target.checked)}
-          />
-          <span>
-            IT企業
-            <DirtyDot visible={Boolean(fieldDirty?.is_it_company)} />
-          </span>
-        </label>
-
         {!exp.is_it_company && (
           <div className={styles.stackSection}>
             <label>
@@ -250,7 +258,7 @@ export function CareerExperienceEditor({
 
         {exp.is_it_company && (
           <div className={styles.stackSection}>
-            <h3>取引先</h3>
+            <h3>案件情報</h3>
             {exp.clients.map((client, clientIndex) => (
               <ClientEditor
                 key={`client-${expIndex}-${clientIndex}`}

--- a/frontend/src/components/forms/CareerFormEditors/ClientEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/ClientEditor.tsx
@@ -67,7 +67,7 @@ export function ClientEditor({
         {!client.is_vacation && client.has_client && (
           <label className={styles.clientNameLabel}>
             <span>
-              取引先名（呼称）
+              案件名
               <DirtyDot visible={Boolean(dirty?.self)} />
             </span>
             <input

--- a/frontend/src/components/forms/CareerResumeForm.module.css
+++ b/frontend/src/components/forms/CareerResumeForm.module.css
@@ -97,6 +97,20 @@
   white-space: nowrap;
 }
 
+/* 会社名・事業内容と同じグリッド行に並べる IT企業トグル。
+   ラベル（グローバル label { display: grid }）の下段にこのトグルを置き、
+   入力欄と同じ高さ・同じ段で横並びにする（上段は labelText スペーサで高さを合わせる）。 */
+.companyTypeToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  /* 入力欄の高さに合わせる */
+  height: 2.6rem;
+  white-space: nowrap;
+}
+
 /* split の親。コンテナクエリの基準にする（split に実際に割り当てられる幅で縦積み判定）。
    ビューポート幅ではなくこの幅で判定することで、サイドバー展開/折りたたみにも追従する。 */
 .splitWrap {

--- a/frontend/src/components/forms/ProjectModal.tsx
+++ b/frontend/src/components/forms/ProjectModal.tsx
@@ -268,10 +268,10 @@ export function ProjectModal({
               labelAdornment={<DirtyDot visible={dirty.fields.description} />}
             />
 
-            {/* 技術スタック */}
+            {/* スキルセット */}
             <div className={styles.stackSection}>
               <h3>
-                技術スタック ※プルダウンにないものはテキストで入力できます。
+                スキルセット ※プルダウンにないものはテキストで入力できます。
                 <DirtyDot visible={dirty.technology_stacks} />
               </h3>
               <div className={styles.stackGrid}>
@@ -299,7 +299,7 @@ export function ProjectModal({
                       type="button"
                       className={styles.chipRemove}
                       onClick={() => removeTechStack(stackIndex)}
-                      aria-label="技術スタックを削除"
+                      aria-label="スキルセットを削除"
                     >
                       &times;
                     </button>

--- a/frontend/src/components/forms/ProjectModal.tsx
+++ b/frontend/src/components/forms/ProjectModal.tsx
@@ -25,7 +25,7 @@ type ProjectModalProps = {
   onSave: (project: CareerProjectForm) => void;
   /** 閉じるコールバック */
   onClose: () => void;
-  /** カテゴリごとの技術スタック名称リスト */
+  /** カテゴリごとのスキルセット名称リスト */
   techStackNamesByCategory: Map<string, string[]>;
   /**
    * PDF 取り込み補助。PDF が選択されている時はモーダル内の右カラムに原本ビューを再掲する。

--- a/frontend/src/components/forms/sections/CareerQualificationsSection.tsx
+++ b/frontend/src/components/forms/sections/CareerQualificationsSection.tsx
@@ -87,7 +87,8 @@ export function CareerQualificationsSection({
               const rowDirty = qualificationsDirty?.[index];
               return (
                 <div key={`qualification-${index}`} className={shared.entry}>
-                  <div className={shared.inline}>
+                  {/* 資格名:取得日 = 7:3 の幅比で配置 */}
+                  <div className={shared.inline} style={{ gridTemplateColumns: "7fr 3fr" }}>
                     <label>
                       <span className={shared.labelText}>
                         資格名


### PR DESCRIPTION
## 概要

職務経歴書の PDF 出力で 1 ページ目に余分な余白が残る問題の修正を中心に、PDF/Markdown の出力表記とフォーム UI の調整をまとめて行います。

> 注: 本ブランチには未マージの既存コミット `resume PDF space fix`（会社ブロックのページ跨ぎ許可）も含まれます。

## 変更内容

### PDF 出力（`backend/app/services/pdf/`）
- **1 ページ目の余分な余白を解消**: `.project { page-break-inside: avoid }` を削除（収まらない案件が丸ごと次ページへ送られ、枠付き company 内に約 48mm の余白が残っていた）。あわせて `body { margin: 0 }` で先頭の既定余白も除去
- **表分割時の見出し繰り返し**: プロジェクト表を `<thead>`/`<tbody>` 化し、ページ境界で分割された際に列見出しを継続ページにも表示
- **体制カラムの廃止**: 表の「体制」列を削除し、役割行へ `役割：X、体制：6名（PM：1名、SE：6名）` 形式で併記。空いた幅は業務内容（`.desc` 60%→75%）へ
- **表記統一**: 列見出し「開発環境」→「スキルセット」、見出し「取引先名：」→「案件名：」

### Markdown 出力（`backend/app/services/markdown/`）
- フィールドラベル「技術スタック」→「スキルセット」

### フォーム UI（`frontend/src/components/forms/`）
- IT企業チェックを会社名・事業内容と同一行・入力欄と横並びに配置（幅比 会社名:事業内容:IT企業 = 4.5:5:0.5）
- 資格入力の幅比を 資格名:取得日 = 7:3 に調整
- スキル入力ラベル「技術スタック」→「スキルセット」に統一
- 取引先名ラベル「取引先名（呼称）」→「案件名」

## テスト
- `make ci` 通過（backend lint/test、frontend lint、vitest 205 passed、build 成功）
- 表示文言・レイアウト中心の差分のため新規ユニットテストは追加せず。新規ルート/認証/レイアウト変更が無いため E2E トリガー対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated resume pagination and table layout for improved formatting and reduced large whitespace.
  * Tweaked form layout and spacing (including a new inline toggle style) for cleaner alignment.

* **Refactor**
  * Simplified project table by consolidating columns and moving team details into the project header.
  * Adjusted qualification row layout for clearer label/date sizing.

* **Localization**
  * Unified labels: "技術スタック" → "スキルセット" and client label changed to "案件名".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->