### PR TITLE
docs: PR #302 レビュー指摘対応（コメント表記を UI に統一）

### DIFF
--- a/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
@@ -116,7 +116,7 @@ export function CareerExperienceEditor({
               placeholder="例: SES事業、受託開発"
             />
           </label>
-          {/* IT企業かどうか（非ITは取引先を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
+          {/* IT企業かどうか（非ITは案件を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
               上段は labelText のスペーサで隣のラベル行と高さを合わせ、下段のトグルを入力欄と横並びにする。 */}
           <label>
             <span className={shared.labelText} aria-hidden="true">

--- a/frontend/src/components/forms/ProjectModal.tsx
+++ b/frontend/src/components/forms/ProjectModal.tsx
@@ -25,7 +25,7 @@ type ProjectModalProps = {
   onSave: (project: CareerProjectForm) => void;
   /** 閉じるコールバック */
   onClose: () => void;
-  /** カテゴリごとの技術スタック名称リスト */
+  /** カテゴリごとのスキルセット名称リスト */
   techStackNamesByCategory: Map<string, string[]>;
   /**
    * PDF 取り込み補助。PDF が選択されている時はモーダル内の右カラムに原本ビューを再掲する。


### PR DESCRIPTION
## 概要

PR #302 への CodeRabbit レビュー指摘 2 件を対応します。いずれも **UI / 出力の表記統一に取り残されたコード内コメントの修正**で、コメント文言のみの変更です（識別子・挙動・型に変更なし）。

PR #302 のブランチ (`fix/resume-pdf-format-and-form`) にスタックする形で取り込めるよう、base を `main` ではなく同ブランチにしています。

## 変更内容

### 1. `frontend/src/components/forms/ProjectModal.tsx`
- `techStackNamesByCategory` prop の JSDoc が旧表記「技術スタック」のまま、UI ラベル（スキルセット）と不一致だったため修正。
- `カテゴリごとの技術スタック名称リスト` → `カテゴリごとのスキルセット名称リスト`
- prop 名 `techStackNamesByCategory` は変更なし。

### 2. `frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx`
- IT企業トグル周辺の説明コメントが旧表記「取引先」のままだったため、表記統一（取引先名→案件名）に合わせて修正。
- `非ITは取引先を持たず詳細のみ` → `非ITは案件を持たず詳細のみ`
- レイアウト注記はそのまま維持。

## スコープ判断
- `CareerExperienceEditor.tsx` には props の JSDoc・ボタン文言など他にも「取引先」が残っていますが、今回の指摘は当該コメントブロックに限定されているため、最小スコープで該当箇所のみ修正しています。

## テスト
- コメント文言のみの変更で、型・挙動・lint に影響なし。
- 本環境に `nix` が無いため `make lint-frontend` は未実行（コメント変更のため影響なしと判断）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS3tqwNQxUSpyvfCfmtWgC)_