### PR TITLE
fix: インポート素材の流し込みをカーソル位置挿入 + Undo 対応にする

### DIFF
--- a/frontend/e2e/career-import-assist.spec.ts
+++ b/frontend/e2e/career-import-assist.spec.ts
@@ -91,7 +91,7 @@ test.describe("職務経歴書 ファイル取り込み補助", () => {
     await expect(page.getByText("dropped.md")).toBeVisible();
   });
 
-  test("原本上で選択した文字がフォーカス中の入力欄へ流し込まれる", async ({ page }) => {
+  test("原本上で選択した文字がフォーカス中の入力欄のカーソル位置へ挿入される", async ({ page }) => {
     await importInput(page).setInputFiles({
       name: "resume.md",
       mimeType: "text/markdown",
@@ -99,7 +99,8 @@ test.describe("職務経歴書 ファイル取り込み補助", () => {
     });
     await expect(markdownBody(page).getByText("取り込みテスト項目")).toBeVisible();
 
-    // 流し込み先として氏名欄をフォーカス（focusin で「最後にフォーカスした入力欄」に記録される）
+    // 流し込み先として氏名欄（モックで "山田 太郎" がロード済み）をフォーカスする
+    // （focusin で「最後にフォーカスした入力欄」に記録される）。
     const nameInput = page.getByPlaceholder("例: 山田 太郎");
     await nameInput.click();
 
@@ -116,7 +117,11 @@ test.describe("職務経歴書 ファイル取り込み補助", () => {
       target.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
     });
 
-    await expect(nameInput).toHaveValue("取り込みテスト項目");
+    // 既存値 "山田 太郎" を置換せず、カーソル位置へ挿入される（旧仕様では全置換され
+    // "取り込みテスト項目" だけになっていた）。このプログラム的な選択操作では caret が
+    // 先頭に戻るため先頭挿入になるが、検証の主眼は「既存値が保持されること」。
+    // カーソル位置挿入そのものの精緻な検証はユニットテスト側が担う。
+    await expect(nameInput).toHaveValue("取り込みテスト項目山田 太郎");
   });
 
   test("拡張子が pdf/md 以外（.txt）だと未対応エラーを表示し描画しない", async ({ page }) => {

--- a/frontend/src/hooks/career/useResumeImportAssist.test.ts
+++ b/frontend/src/hooks/career/useResumeImportAssist.test.ts
@@ -1,7 +1,7 @@
 import type { ChangeEvent } from "react";
 
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { IMPORT_ASSIST_MESSAGES } from "../../constants/messages";
 import { useResumeImportAssist } from "./useResumeImportAssist";
@@ -137,29 +137,53 @@ describe("useResumeImportAssist", () => {
     expect(result.current.error).toBe(IMPORT_ASSIST_MESSAGES.UNSUPPORTED_TYPE);
   });
 
-  it("fillSelection はフォーカス中の入力欄へ流し込む", () => {
+  it("fillSelection はフォーカス中の入力欄のカーソル位置へ挿入する", () => {
     const { result } = renderHook(() => useResumeImportAssist());
     const input = document.createElement("input");
     input.type = "text";
+    input.value = "株式会社";
     document.body.appendChild(input);
     act(() => focusAndRegister(input));
+    // 「株式会社|」の末尾にカーソルを置く。
+    input.setSelectionRange(4, 4);
 
-    act(() => result.current.fillSelection("株式会社ABC"));
+    act(() => result.current.fillSelection("ABC"));
 
     expect(input.value).toBe("株式会社ABC");
     expect(result.current.error).toBeNull();
   });
 
-  it("textarea には改行で追記する", () => {
+  it("textarea にはカーソル位置へ挿入する（末尾改行追記しない）", () => {
     const { result } = renderHook(() => useResumeImportAssist());
     const textarea = document.createElement("textarea");
     textarea.value = "既存テキスト";
     document.body.appendChild(textarea);
     act(() => focusAndRegister(textarea));
+    // 「既存|テキスト」の位置にカーソルを置く。
+    textarea.setSelectionRange(2, 2);
 
-    act(() => result.current.fillSelection("追記分"));
+    act(() => result.current.fillSelection("挿入分"));
 
-    expect(textarea.value).toBe("既存テキスト\n追記分");
+    expect(textarea.value).toBe("既存挿入分テキスト");
+  });
+
+  it("execCommand が使える環境ではカーソル位置挿入に execCommand を使う（undo 履歴の保持）", () => {
+    const { result } = renderHook(() => useResumeImportAssist());
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    act(() => focusAndRegister(textarea));
+    // jsdom には execCommand が無い/no-op のため、true を返すスタブで主経路を通す。
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", { value: execCommand, configurable: true });
+
+    try {
+      act(() => result.current.fillSelection("挿入分"));
+
+      expect(execCommand).toHaveBeenCalledWith("insertText", false, "挿入分");
+    } finally {
+      // 後続テストへ影響しないよう execCommand スタブを除去する。
+      delete (document as unknown as { execCommand?: unknown }).execCommand;
+    }
   });
 
   it("流し込み先が未選択ならエラーを出す", () => {

--- a/frontend/src/hooks/career/useResumeImportAssist.ts
+++ b/frontend/src/hooks/career/useResumeImportAssist.ts
@@ -193,9 +193,9 @@ export function useResumeImportAssist(): UseResumeImportAssistReturn {
       return;
     }
     setError(null);
+    // assignToElement が挿入前に el へフォーカスするため（緑枠を維持し、続けて流し込める）、
+    // ここで改めて focus する必要はない。
     assignToElement(el, trimmed);
-    // 流し込み先にフォーカスを戻す（緑枠を維持し、続けて流し込めるようにする）
-    el.focus();
   }, []);
 
   return {

--- a/frontend/src/hooks/career/useResumeImportAssist.ts
+++ b/frontend/src/hooks/career/useResumeImportAssist.ts
@@ -53,15 +53,37 @@ function detectKind(file: File): ImportFileKind | null {
   return null;
 }
 
-/** controlled input/textarea に値を流し込み、React の onChange を発火させる。 */
+/**
+ * controlled input/textarea のカーソル位置に値を流し込み、React の onChange を発火させる。
+ *
+ * native value セッターで全置換 + 末尾改行追記していた旧実装は、(1) カーソル位置を無視して
+ * 末尾に改行付きで追記される、(2) ブラウザの undo 履歴に乗らず Cmd+Z で戻せない、という
+ * 2 つの不満があった。`document.execCommand("insertText")` はカーソル位置に挿入しつつ
+ * ネイティブの undo 履歴に記録し、`input` イベントも自然発火して React の onChange に反映される。
+ * execCommand は非推奨 API だが、プログラム挿入で undo を保つ代替手段が無いため採用する。
+ */
 function assignToElement(el: HTMLInputElement | HTMLTextAreaElement, text: string): void {
-  const isTextarea = el.tagName === "TEXTAREA";
-  const proto = isTextarea ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  el.focus();
+  if (typeof document.execCommand === "function" && document.execCommand("insertText", false, text)) {
+    return;
+  }
+  // フォールバック（execCommand 非対応環境: jsdom 等）。
+  // selectionStart/End からカーソル位置に挿入し、native setter + input イベントで React に反映する。
+  insertAtCaretFallback(el, text);
+}
+
+/** execCommand が使えない環境向けに、カーソル位置への挿入を手動で再現するフォールバック。 */
+function insertAtCaretFallback(el: HTMLInputElement | HTMLTextAreaElement, text: string): void {
+  const proto = el.tagName === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
   if (!setter) return;
-  // テキストエリアは追記（複数箇所を続けて流し込めるように）、その他は置換
-  const next = isTextarea && el.value.trim() ? `${el.value}\n${text}` : text;
+  const start = el.selectionStart ?? el.value.length;
+  const end = el.selectionEnd ?? el.value.length;
+  const next = `${el.value.slice(0, start)}${text}${el.value.slice(end)}`;
   setter.call(el, next);
+  // caret を挿入したテキストの直後に移動し、続けて流し込めるようにする。
+  const caret = start + text.length;
+  el.setSelectionRange(caret, caret);
   el.dispatchEvent(new Event("input", { bubbles: true }));
 }
 


### PR DESCRIPTION
## 概要

職務経歴書の取り込み機能で、原本（PDF/Markdown）上の選択テキストを入力欄へ流し込む際の 2 つの不満を解消する。

## 課題

1. **改行されて末尾に追記される**: textarea へ流し込むと、カーソル位置ではなく既存テキストの末尾に `\n` 付きで追記されていた。
2. **Cmd+Z で戻せない**: ネイティブ value セッター経由で値を書き換え `input` イベントを手動発火していたため、ブラウザの undo 履歴に乗らず取り消せなかった。

どちらも `frontend/src/hooks/career/useResumeImportAssist.ts` の `assignToElement()` が原因。

## 変更内容

- `assignToElement()` を `document.execCommand("insertText", ...)` ベースに置き換え。1 つの API で以下を満たす:
  - **カーソル位置に挿入**（末尾追記・強制改行を廃止、textarea/input を統一）
  - **Undo 対応**（ネイティブ編集として undo 履歴に記録 → Cmd+Z / Ctrl+Z で戻せる）
  - **React 反映**（`input` イベントが自然発火し既存の `onChange` がそのまま反応）
- execCommand 非対応環境（jsdom 等）向けに `insertAtCaretFallback`（selectionStart/End でカーソル位置挿入 → native setter → caret 前進 → `input` 発火）を追加。

> `execCommand` は非推奨 API だが、プログラム挿入で undo 履歴を保つ現実的な代替手段が無いため採用（全モダンブラウザ対応）。

## テスト

`useResumeImportAssist.test.ts` を更新:
- 「textarea には改行で追記する」→「カーソル位置へ挿入する（末尾改行追記しない）」に置換
- input も caret 位置挿入を検証する形に調整
- `document.execCommand` を spy し、主経路（undo 対応経路）が `insertText` 引数で呼ばれることを検証するケースを追加

## 検証

- ✅ vitest（`useResumeImportAssist.test.ts` 14 ケース pass、全体も pass）
- ✅ ESLint clean
- ✅ build（tsc + vite）成功

最新 main に rebase 済み。既存ページ/ルート/認証/レイアウトに触れないため E2E トリガーには非該当。

> undo 挙動自体は jsdom で検証できないため、実ブラウザでの「カーソル位置挿入 → Cmd+Z 取り消し」確認を推奨。

https://claude.ai/code/session_01PpafBZRByMNk4nTzFYxQKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpafBZRByMNk4nTzFYxQKb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text insertion behavior in resume import functionality to insert at cursor position rather than appending.
  * Enhanced undo/redo history support when inserting text into input fields.
  * Refined cursor positioning logic for consistent insertion behavior across input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->