### PR TITLE
職務経歴書の保存時バリデーションで該当フィールドへ自動フォーカス

### DIFF
--- a/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/CareerExperienceEditor.tsx
@@ -1,9 +1,11 @@
 import { CAPITAL_UNITS } from "../../../constants";
 import type { CareerClientFieldKey, CareerExperienceFieldKey } from "../../../formTypes";
 import type { ExperienceDirty } from "../../../hooks/career/useCareerDirty";
+import { useFocusOnMatch } from "../../../hooks/useFocusOnMatch";
 import {
   validateDateRange,
   type CareerExperienceForm,
+  type CareerFieldLocator,
   type CareerProjectForm,
 } from "../../../payloadBuilders";
 import { UI_MESSAGES } from "../../../constants/messages";
@@ -54,6 +56,10 @@ type CareerExperienceEditorProps = {
   projectSummary: (proj: CareerProjectForm) => string;
   /** この経歴の dirty 情報。未指定なら 🔴 表示なし。 */
   dirty?: ExperienceDirty;
+  /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠・折りたたみ展開用） */
+  focusLocator?: CareerFieldLocator | null;
+  /** フォーカス発火の nonce（折りたたみ自動展開の再発火鍵） */
+  focusNonce?: number;
 };
 
 /**
@@ -75,12 +81,36 @@ export function CareerExperienceEditor({
   onRemoveExperience,
   projectSummary,
   dirty,
+  focusLocator = null,
+  focusNonce = 0,
 }: CareerExperienceEditorProps) {
   const fieldDirty = dirty?.fields;
+
+  /** この経歴の指定フィールドがバリデーション失敗対象か */
+  const expField = (field: "company" | "business_description" | "start_date" | "end_date" | "description") =>
+    focusLocator?.kind === "experience" &&
+    focusLocator.expIndex === expIndex &&
+    focusLocator.field === field;
+
+  const companyRef = useFocusOnMatch<HTMLInputElement>(expField("company"));
+  const businessRef = useFocusOnMatch<HTMLInputElement>(expField("business_description"));
+  const startDateRef = useFocusOnMatch<HTMLInputElement>(expField("start_date"));
+  const endDateRef = useFocusOnMatch<HTMLInputElement>(expField("end_date"));
+  const descriptionRef = useFocusOnMatch<HTMLTextAreaElement>(expField("description"));
+
+  // この経歴を対象とするエラー（経歴フィールド・休暇・プロジェクト）なら折りたたみを開く。
+  const targetsThisExp =
+    (focusLocator?.kind === "experience" ||
+      focusLocator?.kind === "vacation" ||
+      focusLocator?.kind === "project") &&
+    focusLocator.expIndex === expIndex;
+  const forceOpenKey = targetsThisExp ? focusNonce : null;
+
   return (
     <div className={shared.entry}>
       <Collapsible
         variant="entry"
+        forceOpenKey={forceOpenKey}
         title={
           <>
             {exp.company || "(会社名未入力)"}
@@ -105,9 +135,11 @@ export function CareerExperienceEditor({
               <DirtyDot visible={Boolean(fieldDirty?.company)} />
             </span>
             <input
+              ref={companyRef}
               type="text"
               value={exp.company}
               onChange={(e) => onUpdateExperienceField(expIndex, "company", e.target.value)}
+              aria-invalid={expField("company") || undefined}
             />
           </label>
           <label>
@@ -117,12 +149,14 @@ export function CareerExperienceEditor({
               <DirtyDot visible={Boolean(fieldDirty?.business_description)} />
             </span>
             <input
+              ref={businessRef}
               type="text"
               value={exp.business_description}
               onChange={(e) =>
                 onUpdateExperienceField(expIndex, "business_description", e.target.value)
               }
               placeholder="例: SES事業、受託開発"
+              aria-invalid={expField("business_description") || undefined}
             />
           </label>
           {/* IT企業かどうか（非ITは案件を持たず詳細のみ）。会社名・事業内容と同じ行に配置。
@@ -155,9 +189,11 @@ export function CareerExperienceEditor({
               <DirtyDot visible={Boolean(fieldDirty?.start_date)} />
             </span>
             <input
+              ref={startDateRef}
               type="month"
               value={exp.start_date}
               onChange={(e) => onUpdateExperienceField(expIndex, "start_date", e.target.value)}
+              aria-invalid={expField("start_date") || undefined}
             />
           </label>
           <label>
@@ -183,9 +219,11 @@ export function CareerExperienceEditor({
                 <DirtyDot visible={Boolean(fieldDirty?.end_date)} />
               </span>
               <input
+                ref={endDateRef}
                 type="month"
                 value={exp.end_date}
                 onChange={(e) => onUpdateExperienceField(expIndex, "end_date", e.target.value)}
+                aria-invalid={expField("end_date") || undefined}
               />
             </label>
           )}
@@ -254,12 +292,14 @@ export function CareerExperienceEditor({
                 <DirtyDot visible={Boolean(fieldDirty?.description)} />
               </span>
               <textarea
+                ref={descriptionRef}
                 value={exp.description}
                 onChange={(e) =>
                   onUpdateExperienceField(expIndex, "description", e.target.value)
                 }
                 rows={6}
                 placeholder="例: 店舗運営・在庫管理・スタッフ教育を担当…"
+                aria-invalid={expField("description") || undefined}
               />
             </label>
           </div>
@@ -283,6 +323,7 @@ export function CareerExperienceEditor({
                 onOpenProjectModal={onOpenProjectModal}
                 onRemoveClient={onRemoveClient}
                 projectSummary={projectSummary}
+                focusLocator={focusLocator}
               />
             ))}
             <button

--- a/frontend/src/components/forms/CareerFormEditors/ClientEditor.tsx
+++ b/frontend/src/components/forms/CareerFormEditors/ClientEditor.tsx
@@ -1,8 +1,10 @@
 import type { CareerClientFieldKey } from "../../../formTypes";
 import type { ClientDirty } from "../../../hooks/career/useCareerDirty";
+import { useFocusOnMatch } from "../../../hooks/useFocusOnMatch";
 import {
   validateDateRange,
   type CareerClientForm,
+  type CareerFieldLocator,
   type CareerProjectForm,
 } from "../../../payloadBuilders";
 import { UI_MESSAGES } from "../../../constants/messages";
@@ -43,6 +45,8 @@ type ClientEditorProps = {
   onRemoveClient: (expIndex: number, clientIndex: number) => void;
   /** プロジェクトサマリーテキストを生成する関数 */
   projectSummary: (proj: CareerProjectForm) => string;
+  /** バリデーション失敗フィールドの位置情報（休暇期間のフォーカス・赤枠用） */
+  focusLocator?: CareerFieldLocator | null;
 };
 
 /**
@@ -63,7 +67,18 @@ export function ClientEditor({
   onOpenProjectModal,
   onRemoveClient,
   projectSummary,
+  focusLocator = null,
 }: ClientEditorProps) {
+  /** この取引先の休暇期間フィールドがバリデーション失敗対象か */
+  const vacationField = (field: "start_date" | "end_date") =>
+    focusLocator?.kind === "vacation" &&
+    focusLocator.expIndex === expIndex &&
+    focusLocator.clientIndex === clientIndex &&
+    focusLocator.field === field;
+
+  const vacationStartRef = useFocusOnMatch<HTMLInputElement>(vacationField("start_date"));
+  const vacationEndRef = useFocusOnMatch<HTMLInputElement>(vacationField("end_date"));
+
   return (
     <div className={shared.entry}>
       <div className={styles.clientHeader}>
@@ -124,11 +139,13 @@ export function ClientEditor({
                 <span className={shared.requiredBadge}>必須</span>
               </span>
               <input
+                ref={vacationStartRef}
                 type="month"
                 value={client.vacation_start_date}
                 onChange={(e) =>
                   onUpdateClientField(expIndex, clientIndex, "vacation_start_date", e.target.value)
                 }
+                aria-invalid={vacationField("start_date") || undefined}
               />
             </label>
             <label>
@@ -154,11 +171,13 @@ export function ClientEditor({
                   <span className={shared.requiredBadge}>必須</span>
                 </span>
                 <input
+                  ref={vacationEndRef}
                   type="month"
                   value={client.vacation_end_date}
                   onChange={(e) =>
                     onUpdateClientField(expIndex, clientIndex, "vacation_end_date", e.target.value)
                   }
+                  aria-invalid={vacationField("end_date") || undefined}
                 />
               </label>
             )}

--- a/frontend/src/components/forms/CareerResumeForm.tsx
+++ b/frontend/src/components/forms/CareerResumeForm.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties, FormEvent, useMemo, useRef, useState } from "react";
+import { CSSProperties, FormEvent, useCallback, useMemo, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 import {
   createCareerResume,
@@ -16,7 +17,8 @@ import { useImportPanelLayout } from "../../hooks/career/useImportPanelLayout";
 import { useResumeDiffPreview } from "../../hooks/career/useResumeDiffPreview";
 import { useResumeImportAssist } from "../../hooks/career/useResumeImportAssist";
 import { useDocumentForm } from "../../hooks/useDocumentForm";
-import { buildCareerPayload } from "../../payloadBuilders";
+import { buildCareerPayload, validateCareerForm } from "../../payloadBuilders";
+import type { CareerFieldLocator, CareerFormState } from "../../payloadBuilders";
 import { buildCareerChanges } from "../../utils/careerDiff";
 import type { CareerTextFieldKey } from "../../formTypes";
 import { useQualifications, useTechnologyStacks } from "../../hooks/useMasterData";
@@ -52,6 +54,8 @@ export function CareerResumeForm() {
     deleting,
     error: formError,
     success: formSuccess,
+    setError,
+    setSuccess,
     save,
     deleteDoc,
     saveButtonText,
@@ -111,12 +115,43 @@ export function CareerResumeForm() {
   /** フォームデータ・技術スタック・資格の3つが揃った時に送信可能 */
   const canSubmit = !loading && !techLoading && !qualLoading;
 
+  /**
+   * バリデーション失敗フィールドの位置と nonce。保存時にセットし、
+   * 該当入力へのフォーカス・赤枠表示・折りたたみ自動展開に使う。
+   * nonce は「同じフィールドで再度保存した時」も折りたたみ展開 effect を再発火させるための鍵。
+   */
+  const [focusTarget, setFocusTarget] = useState<{
+    locator: CareerFieldLocator;
+    nonce: number;
+  } | null>(null);
+  const focusNonceRef = useRef(0);
+
+  /** 編集が入ったらフォーカス強調を解除する（赤枠を消す）setForm ラッパー。 */
+  const setFormAndClearFocus = useCallback<Dispatch<SetStateAction<CareerFormState>>>(
+    (action) => {
+      setFocusTarget(null);
+      setForm(action);
+    },
+    [setForm],
+  );
+
   const onChangeField = (key: CareerTextFieldKey, value: string) => {
+    setFocusTarget(null);
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
   const onSubmit = (event: FormEvent) => {
     event.preventDefault();
+    // 保存前にフォーム全体を検証し、最初のエラーフィールドへフォーカスする。
+    const validation = validateCareerForm(form);
+    if (validation) {
+      setError(validation.message);
+      setSuccess(null);
+      focusNonceRef.current += 1;
+      setFocusTarget({ locator: validation.locator, nonce: focusNonceRef.current });
+      return;
+    }
+    setFocusTarget(null);
     // 変更が無ければ確認を挟まずそのまま保存。変更があれば確認ダイアログを開く。
     if (changes.length === 0) {
       void save();
@@ -130,6 +165,9 @@ export function CareerResumeForm() {
     await save();
     setShowSaveConfirm(false);
   };
+
+  const focusLocator = focusTarget?.locator ?? null;
+  const focusNonce = focusTarget?.nonce ?? 0;
 
   const handleDelete = async () => {
     await deleteDoc();
@@ -162,7 +200,10 @@ export function CareerResumeForm() {
         />
       )}
       {previewUrl && <PdfPreviewModal previewUrl={previewUrl} onClose={closePreview} />}
-      <form onSubmit={onSubmit}>
+      {/* noValidate: 必須チェックはブラウザ標準ではなく validateCareerForm に一本化する。
+          標準の required バブルが先に発火すると、該当フィールドへの独自フォーカス・赤枠・
+          日本語メッセージが出せず挙動が不統一になるため抑止する。 */}
+      <form onSubmit={onSubmit} noValidate>
         <div className={shared.pageHeader}>
           <h1>職務経歴書</h1>
           <div className={shared.pageHeaderActions}>
@@ -228,6 +269,7 @@ export function CareerResumeForm() {
                   onChange={onChangeField}
                   fullNameDirty={dirty.full_name}
                   careerSummaryDirty={dirty.career_summary}
+                  focusLocator={focusLocator}
                 />
 
                 {/* 職務経歴セクション */}
@@ -244,11 +286,13 @@ export function CareerResumeForm() {
                 ) : (
                   <CareerExperienceSection
                     experiences={form.experiences}
-                    setForm={setForm}
+                    setForm={setFormAndClearFocus}
                     techStackOptions={techStackOptions}
                     experiencesDirty={dirty.experiences}
                     sectionDirty={dirty.experiencesAny}
                     assist={assist}
+                    focusLocator={focusLocator}
+                    focusNonce={focusNonce}
                   />
                 )}
 
@@ -257,9 +301,11 @@ export function CareerResumeForm() {
                   qualifications={form.qualifications}
                   qualificationNames={qualificationNames}
                   loading={loading}
-                  setForm={setForm}
+                  setForm={setFormAndClearFocus}
                   qualificationsDirty={dirty.qualifications}
                   sectionDirty={dirty.qualificationsAny}
+                  focusLocator={focusLocator}
+                  focusNonce={focusNonce}
                 />
 
                 {/* 自己PR */}
@@ -268,6 +314,7 @@ export function CareerResumeForm() {
                   loading={loading}
                   onChange={(v) => onChangeField("self_pr", v)}
                   dirty={dirty.self_pr}
+                  focusLocator={focusLocator}
                 />
               </div>
 

--- a/frontend/src/components/forms/Combobox.tsx
+++ b/frontend/src/components/forms/Combobox.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type Ref } from "react";
 
 import styles from "./Combobox.module.css";
 
@@ -8,10 +8,22 @@ type ComboboxProps = {
   options: string[];
   placeholder?: string;
   allowCustom?: boolean;
+  /** 内部 input への ref（バリデーション失敗時のフォーカス用） */
+  inputRef?: Ref<HTMLInputElement>;
+  /** バリデーション失敗フィールドとして強調するか（aria-invalid を付与） */
+  invalid?: boolean;
 };
 
 /** 検索可能なプルダウンコンポーネント */
-export function Combobox({ value, onChange, options, placeholder, allowCustom = false }: ComboboxProps) {
+export function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder,
+  allowCustom = false,
+  inputRef,
+  invalid,
+}: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState(value);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -86,6 +98,7 @@ export function Combobox({ value, onChange, options, placeholder, allowCustom = 
   return (
     <div className={styles.container} ref={containerRef}>
       <input
+        ref={inputRef}
         type="text"
         value={query}
         onChange={(e) => {
@@ -100,6 +113,7 @@ export function Combobox({ value, onChange, options, placeholder, allowCustom = 
         role="combobox"
         aria-expanded={open}
         aria-autocomplete="list"
+        aria-invalid={invalid || undefined}
       />
       {open && filtered.length > 0 && (
         <ul className={styles.dropdown} ref={listRef} role="listbox">

--- a/frontend/src/components/forms/MarkdownTextarea.tsx
+++ b/frontend/src/components/forms/MarkdownTextarea.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, type ReactNode, type Ref } from "react";
 import { renderMarkdown } from "../../utils/markdown";
 import shared from "../../styles/shared.module.css";
 import styles from "./MarkdownTextarea.module.css";
@@ -18,12 +18,26 @@ type Props = {
   required?: boolean;
   /** ラベル横に追加する装飾要素（例: 未保存マーク 🔴） */
   labelAdornment?: ReactNode;
+  /** textarea への ref（バリデーション失敗時のフォーカス用） */
+  textareaRef?: Ref<HTMLTextAreaElement>;
+  /** バリデーション失敗フィールドとして強調するか（aria-invalid を付与） */
+  invalid?: boolean;
 };
 
 /**
  * Markdownテキストエリア。入力内容をリアルタイムでプレビュー表示する。
  */
-export function MarkdownTextarea({ label, value, onChange, rows = 3, placeholder, required, labelAdornment }: Props) {
+export function MarkdownTextarea({
+  label,
+  value,
+  onChange,
+  rows = 3,
+  placeholder,
+  required,
+  labelAdornment,
+  textareaRef,
+  invalid,
+}: Props) {
   const renderedHtml = useMemo(() => renderMarkdown(value), [value]);
 
   return (
@@ -35,11 +49,13 @@ export function MarkdownTextarea({ label, value, onChange, rows = 3, placeholder
       </span>
       <div className={styles.editorRow}>
         <textarea
+          ref={textareaRef}
           rows={rows}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           required={required}
+          aria-invalid={invalid || undefined}
           className={styles.editor}
         />
         {value && (

--- a/frontend/src/components/forms/ProjectModal.test.tsx
+++ b/frontend/src/components/forms/ProjectModal.test.tsx
@@ -87,4 +87,23 @@ describe("ProjectModal", () => {
     );
     expect(screen.queryByText(PANEL_MARKER)).not.toBeInTheDocument();
   });
+
+  /** autoFocus 指定で該当期間の開始入力にフォーカス＆ aria-invalid が付くこと */
+  it("autoFocus で指定された期間の開始入力にフォーカスし aria-invalid を付ける", () => {
+    render(
+      <ProjectModal
+        project={emptyProject}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        techStackNamesByCategory={new Map()}
+        autoFocus={{ periodIndex: 0, field: "start_date" }}
+      />,
+    );
+    // 「開始」ラベルの month input が対象。
+    const startInput = document.querySelector(
+      'input[type="month"][aria-invalid="true"]',
+    ) as HTMLInputElement | null;
+    expect(startInput).not.toBeNull();
+    expect(document.activeElement).toBe(startInput);
+  });
 });

--- a/frontend/src/components/forms/ProjectModal.tsx
+++ b/frontend/src/components/forms/ProjectModal.tsx
@@ -1,15 +1,17 @@
 import { useRef, type CSSProperties } from "react";
 
-import type { CareerProjectForm } from "../../payloadBuilders";
+import type { CareerProjectForm, CareerProjectPeriodForm } from "../../payloadBuilders";
 import {
   careerTechnologyStackCategories,
   careerTechnologyStackCategoryLabels,
   phaseOptions,
   teamRoleOptions,
 } from "../../constants";
+import type { CareerProjectPeriodFieldKey } from "../../formTypes";
 import { useProjectFormDirty } from "../../hooks/career/useProjectFormDirty";
 import { useProjectModalForm } from "../../hooks/career/useProjectModalForm";
 import { useImportPanelLayout } from "../../hooks/career/useImportPanelLayout";
+import { useFocusOnMatch } from "../../hooks/useFocusOnMatch";
 import type { UseResumeImportAssistReturn } from "../../hooks/career/useResumeImportAssist";
 import { Combobox } from "./Combobox";
 import { MarkdownTextarea } from "./MarkdownTextarea";
@@ -33,7 +35,89 @@ type ProjectModalProps = {
    * 奪うため、子モーダルを開いている間でも流し込めるようモーダル内に再掲する。
    */
   assist?: UseResumeImportAssistReturn;
+  /**
+   * バリデーション失敗時に自動フォーカスする期間入力の指定。
+   * `CareerExperienceSection` が保存エラー検出時にモーダルを開いて渡す。
+   */
+  autoFocus?: { periodIndex: number; field: "start_date" | "end_date" };
 };
+
+/** プロジェクト期間 1 行分の入力。期間は可変長のため別コンポーネントにして focus hook を使う。 */
+type ProjectPeriodRowProps = {
+  period: CareerProjectPeriodForm;
+  periodIndex: number;
+  canRemove: boolean;
+  autoFocus?: { periodIndex: number; field: "start_date" | "end_date" };
+  onUpdate: (periodIndex: number, key: CareerProjectPeriodFieldKey, value: string | boolean) => void;
+  onRemove: (periodIndex: number) => void;
+};
+
+function ProjectPeriodRow({
+  period,
+  periodIndex,
+  canRemove,
+  autoFocus,
+  onUpdate,
+  onRemove,
+}: ProjectPeriodRowProps) {
+  const startInvalid = autoFocus?.periodIndex === periodIndex && autoFocus.field === "start_date";
+  const endInvalid = autoFocus?.periodIndex === periodIndex && autoFocus.field === "end_date";
+  const startRef = useFocusOnMatch<HTMLInputElement>(startInvalid);
+  const endRef = useFocusOnMatch<HTMLInputElement>(endInvalid);
+
+  return (
+    <div className={styles.inline}>
+      <label>
+        <span className={shared.labelText}>
+          開始
+          <span className={shared.requiredBadge}>必須</span>
+        </span>
+        <input
+          ref={startRef}
+          type="month"
+          value={period.start_date}
+          onChange={(e) => onUpdate(periodIndex, "start_date", e.target.value)}
+          aria-invalid={startInvalid || undefined}
+        />
+      </label>
+      <label>
+        <span>参画状況</span>
+        <select
+          value={period.is_current ? "current" : "ended"}
+          onChange={(e) => onUpdate(periodIndex, "is_current", e.target.value === "current")}
+        >
+          <option value="ended">終了</option>
+          <option value="current">参画中</option>
+        </select>
+      </label>
+      {!period.is_current && (
+        <label>
+          <span className={shared.labelText}>
+            終了
+            <span className={shared.requiredBadge}>必須</span>
+          </span>
+          <input
+            ref={endRef}
+            type="month"
+            value={period.end_date}
+            onChange={(e) => onUpdate(periodIndex, "end_date", e.target.value)}
+            aria-invalid={endInvalid || undefined}
+          />
+        </label>
+      )}
+      {canRemove && (
+        <button
+          type="button"
+          className={styles.chipRemove}
+          onClick={() => onRemove(periodIndex)}
+          aria-label="期間を削除"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+}
 
 export function ProjectModal({
   project,
@@ -41,6 +125,7 @@ export function ProjectModal({
   onClose,
   techStackNamesByCategory,
   assist,
+  autoFocus,
 }: ProjectModalProps) {
   const {
     local,
@@ -125,56 +210,15 @@ export function ProjectModal({
                 <DirtyDot visible={dirty.periods} />
               </h3>
               {local.periods.map((period, periodIndex) => (
-                <div key={`period-${periodIndex}`} className={styles.inline}>
-                  <label>
-                    <span className={shared.labelText}>
-                      開始
-                      <span className={shared.requiredBadge}>必須</span>
-                    </span>
-                    <input
-                      type="month"
-                      value={period.start_date}
-                      onChange={(e) => updatePeriodField(periodIndex, "start_date", e.target.value)}
-                    />
-                  </label>
-                  <label>
-                    <span>参画状況</span>
-                    <select
-                      value={period.is_current ? "current" : "ended"}
-                      onChange={(e) =>
-                        updatePeriodField(periodIndex, "is_current", e.target.value === "current")
-                      }
-                    >
-                      <option value="ended">終了</option>
-                      <option value="current">参画中</option>
-                    </select>
-                  </label>
-                  {!period.is_current && (
-                    <label>
-                      <span className={shared.labelText}>
-                        終了
-                        <span className={shared.requiredBadge}>必須</span>
-                      </span>
-                      <input
-                        type="month"
-                        value={period.end_date}
-                        onChange={(e) =>
-                          updatePeriodField(periodIndex, "end_date", e.target.value)
-                        }
-                      />
-                    </label>
-                  )}
-                  {local.periods.length > 1 && (
-                    <button
-                      type="button"
-                      className={styles.chipRemove}
-                      onClick={() => removePeriod(periodIndex)}
-                      aria-label="期間を削除"
-                    >
-                      &times;
-                    </button>
-                  )}
-                </div>
+                <ProjectPeriodRow
+                  key={`period-${periodIndex}`}
+                  period={period}
+                  periodIndex={periodIndex}
+                  canRemove={local.periods.length > 1}
+                  autoFocus={autoFocus}
+                  onUpdate={updatePeriodField}
+                  onRemove={removePeriod}
+                />
               ))}
               <button type="button" className={`ghost ${styles.chipAdd}`} onClick={addPeriod}>
                 + 期間を追加

--- a/frontend/src/components/forms/sections/CareerBasicInfoSection.tsx
+++ b/frontend/src/components/forms/sections/CareerBasicInfoSection.tsx
@@ -1,3 +1,5 @@
+import type { CareerFieldLocator } from "../../../payloadBuilders";
+import { useFocusOnMatch } from "../../../hooks/useFocusOnMatch";
 import shared from "../../../styles/shared.module.css";
 import { DirtyDot } from "../../ui/DirtyDot";
 import { Skeleton } from "../../ui/Skeleton";
@@ -17,6 +19,8 @@ type Props = {
   fullNameDirty?: boolean;
   /** 職務要約フィールドが未保存か */
   careerSummaryDirty?: boolean;
+  /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠用） */
+  focusLocator?: CareerFieldLocator | null;
 };
 
 /**
@@ -30,7 +34,13 @@ export function CareerBasicInfoSection({
   onChange,
   fullNameDirty = false,
   careerSummaryDirty = false,
+  focusLocator = null,
 }: Props) {
+  const fullNameInvalid = focusLocator?.kind === "full_name";
+  const careerSummaryInvalid = focusLocator?.kind === "career_summary";
+  const fullNameRef = useFocusOnMatch<HTMLInputElement>(fullNameInvalid);
+  const careerSummaryRef = useFocusOnMatch<HTMLTextAreaElement>(careerSummaryInvalid);
+
   return (
     <section className={shared.section}>
       <label>
@@ -42,11 +52,13 @@ export function CareerBasicInfoSection({
           <Skeleton height="38px" />
         ) : (
           <input
+            ref={fullNameRef}
             type="text"
             value={fullName}
             onChange={(e) => onChange("full_name", e.target.value)}
             placeholder="例: 山田 太郎"
             required
+            aria-invalid={fullNameInvalid || undefined}
           />
         )}
       </label>
@@ -60,6 +72,8 @@ export function CareerBasicInfoSection({
           rows={4}
           required
           labelAdornment={<DirtyDot visible={careerSummaryDirty} />}
+          textareaRef={careerSummaryRef}
+          invalid={careerSummaryInvalid}
         />
       )}
     </section>

--- a/frontend/src/components/forms/sections/CareerExperienceSection.tsx
+++ b/frontend/src/components/forms/sections/CareerExperienceSection.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { Dispatch, SetStateAction } from "react";
 
 import type { ExperienceDirty } from "../../../hooks/career/useCareerDirty";
 import type {
   CareerExperienceForm,
+  CareerFieldLocator,
   CareerFormState,
   CareerProjectForm,
 } from "../../../payloadBuilders";
@@ -32,6 +33,10 @@ type CareerExperienceSectionProps = {
   sectionDirty?: boolean;
   /** PDF 取り込み補助。プロジェクトモーダル内に取り込みパネルを再掲するため受け渡す */
   assist?: UseResumeImportAssistReturn;
+  /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠・折りたたみ展開用） */
+  focusLocator?: CareerFieldLocator | null;
+  /** フォーカス発火の nonce（折りたたみ自動展開の再発火鍵） */
+  focusNonce?: number;
 };
 
 /**
@@ -46,6 +51,8 @@ export function CareerExperienceSection({
   experiencesDirty,
   sectionDirty = false,
   assist,
+  focusLocator = null,
+  focusNonce = 0,
 }: CareerExperienceSectionProps) {
   /** カテゴリごとの技術スタック名称マップを生成する */
   const techStackNamesByCategory = useMemo(() => {
@@ -62,6 +69,30 @@ export function CareerExperienceSection({
 
   const { modalTarget, setModalTarget, modalProject, handleProjectSave, closeModal } =
     useProjectModalState(mutators.getProject, mutators.onProjectSave);
+
+  // プロジェクト配下のバリデーションエラー時は該当プロジェクトのモーダルを自動で開く。
+  // focusLocator は保存のたびに新しい参照になるため、同じプロジェクトでも再発火する。
+  useEffect(() => {
+    if (focusLocator?.kind === "project") {
+      setModalTarget({
+        expIndex: focusLocator.expIndex,
+        clientIndex: focusLocator.clientIndex,
+        projIndex: focusLocator.projIndex,
+      });
+    }
+    // setModalTarget は state setter で安定。focusLocator の変化のみで発火させる。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusLocator]);
+
+  // 開いているモーダルが該当プロジェクトなら、フォーカスすべき期間入力を渡す。
+  const projectAutoFocus =
+    modalTarget &&
+    focusLocator?.kind === "project" &&
+    focusLocator.expIndex === modalTarget.expIndex &&
+    focusLocator.clientIndex === modalTarget.clientIndex &&
+    focusLocator.projIndex === modalTarget.projIndex
+      ? { periodIndex: focusLocator.periodIndex, field: focusLocator.field }
+      : undefined;
 
   /** プロジェクトの期間サマリーテキストを生成する（複数期間は「、」区切り） */
   const projectSummary = (proj: CareerProjectForm) => {
@@ -92,6 +123,7 @@ export function CareerExperienceSection({
           onClose={closeModal}
           techStackNamesByCategory={techStackNamesByCategory}
           assist={assist}
+          autoFocus={projectAutoFocus}
         />
       )}
 
@@ -116,6 +148,8 @@ export function CareerExperienceSection({
           onRemoveExperience={mutators.removeExperience}
           projectSummary={projectSummary}
           dirty={experiencesDirty?.[expIndex]}
+          focusLocator={focusLocator}
+          focusNonce={focusNonce}
         />
       ))}
 

--- a/frontend/src/components/forms/sections/CareerQualificationsSection.tsx
+++ b/frontend/src/components/forms/sections/CareerQualificationsSection.tsx
@@ -1,9 +1,10 @@
 import type { Dispatch, SetStateAction } from "react";
 import { blankResumeQualification } from "../../../constants";
 import type { QualificationDirty } from "../../../hooks/career/useCareerDirty";
-import type { CareerFormState } from "../../../payloadBuilders";
+import type { CareerFieldLocator, CareerFormState } from "../../../payloadBuilders";
 import type { ResumeQualificationItem } from "../../../api/types";
 import { UI_MESSAGES } from "../../../constants/messages";
+import { useFocusOnMatch } from "../../../hooks/useFocusOnMatch";
 import shared from "../../../styles/shared.module.css";
 import styles from "../CareerResumeForm.module.css";
 import { Collapsible } from "../../ui/Collapsible";
@@ -27,7 +28,88 @@ type Props = {
   qualificationsDirty?: QualificationDirty[];
   /** 「資格」セクション全体の未保存集約フラグ。 */
   sectionDirty?: boolean;
+  /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠・折りたたみ展開用） */
+  focusLocator?: CareerFieldLocator | null;
+  /** フォーカス発火の nonce（折りたたみ自動展開の再発火鍵） */
+  focusNonce?: number;
 };
+
+/** 資格 1 行分の入力。可変長のため別コンポーネントにして focus hook を使う。 */
+type QualificationRowProps = {
+  qualification: ResumeQualificationItem;
+  index: number;
+  qualificationNames: string[];
+  rowDirty?: QualificationDirty;
+  focusLocator: CareerFieldLocator | null;
+  onUpdate: (index: number, key: keyof ResumeQualificationItem, value: string) => void;
+  onRemove: (index: number) => void;
+};
+
+function QualificationRow({
+  qualification,
+  index,
+  qualificationNames,
+  rowDirty,
+  focusLocator,
+  onUpdate,
+  onRemove,
+}: QualificationRowProps) {
+  const nameInvalid =
+    focusLocator?.kind === "qualification" &&
+    focusLocator.index === index &&
+    focusLocator.field === "name";
+  const acquiredInvalid =
+    focusLocator?.kind === "qualification" &&
+    focusLocator.index === index &&
+    focusLocator.field === "acquired_date";
+  const nameRef = useFocusOnMatch<HTMLInputElement>(nameInvalid);
+  const acquiredRef = useFocusOnMatch<HTMLInputElement>(acquiredInvalid);
+
+  return (
+    <div className={shared.entry}>
+      <div className={styles.qualificationRow}>
+        {/* 資格名:取得日 = 7:3 の幅比で配置 */}
+        <div className={shared.inline} style={{ gridTemplateColumns: "7fr 3fr" }}>
+          <label>
+            <span className={shared.labelText}>
+              資格名
+              <span className={shared.requiredBadge}>必須</span>
+              ※プルダウンにないものはテキストで入力できます。
+              <DirtyDot visible={Boolean(rowDirty?.fields.name)} />
+            </span>
+            <Combobox
+              value={qualification.name}
+              onChange={(val) => onUpdate(index, "name", val)}
+              options={qualificationNames}
+              placeholder="例: 基本情報技術者試験"
+              allowCustom
+              inputRef={nameRef}
+              invalid={nameInvalid}
+            />
+          </label>
+          <label>
+            <span className={shared.labelText}>
+              取得日
+              <span className={shared.requiredBadge}>必須</span>
+              <DirtyDot visible={Boolean(rowDirty?.fields.acquired_date)} />
+            </span>
+            <input
+              ref={acquiredRef}
+              type="month"
+              value={qualification.acquired_date}
+              onChange={(e) => onUpdate(index, "acquired_date", e.target.value)}
+              aria-invalid={acquiredInvalid || undefined}
+            />
+          </label>
+        </div>
+        <DeleteIconButton
+          label={UI_MESSAGES.RESUME_DELETE_QUALIFICATION}
+          onClick={() => onRemove(index)}
+        />
+      </div>
+    </div>
+  );
+}
 
 /**
  * 職務経歴書の「資格」セクション。資格の追加・削除・編集ハンドラを内包する。
@@ -40,7 +122,11 @@ export function CareerQualificationsSection({
   setForm,
   qualificationsDirty,
   sectionDirty = false,
+  focusLocator = null,
+  focusNonce = 0,
 }: Props) {
+  // 資格欄を対象とするエラーなら折りたたみを自動展開する。
+  const forceOpenKey = focusLocator?.kind === "qualification" ? focusNonce : null;
   /** 資格フィールド変更ハンドラ */
   const updateField = (index: number, key: keyof ResumeQualificationItem, value: string) => {
     setForm((prev) => ({
@@ -74,6 +160,7 @@ export function CareerQualificationsSection({
     <section className={shared.section}>
       <Collapsible
         variant="section"
+        forceOpenKey={forceOpenKey}
         title={
           <>
             資格
@@ -87,49 +174,18 @@ export function CareerQualificationsSection({
           </div>
         ) : (
           <>
-            {qualifications.map((qualification, index) => {
-              const rowDirty = qualificationsDirty?.[index];
-              return (
-                <div key={`qualification-${index}`} className={shared.entry}>
-                  <div className={styles.qualificationRow}>
-                    {/* 資格名:取得日 = 7:3 の幅比で配置 */}
-                    <div className={shared.inline} style={{ gridTemplateColumns: "7fr 3fr" }}>
-                      <label>
-                        <span className={shared.labelText}>
-                          資格名
-                          <span className={shared.requiredBadge}>必須</span>
-                          ※プルダウンにないものはテキストで入力できます。
-                          <DirtyDot visible={Boolean(rowDirty?.fields.name)} />
-                        </span>
-                        <Combobox
-                          value={qualification.name}
-                          onChange={(val) => updateField(index, "name", val)}
-                          options={qualificationNames}
-                          placeholder="例: 基本情報技術者試験"
-                          allowCustom
-                        />
-                      </label>
-                      <label>
-                        <span className={shared.labelText}>
-                          取得日
-                          <span className={shared.requiredBadge}>必須</span>
-                          <DirtyDot visible={Boolean(rowDirty?.fields.acquired_date)} />
-                        </span>
-                        <input
-                          type="month"
-                          value={qualification.acquired_date}
-                          onChange={(e) => updateField(index, "acquired_date", e.target.value)}
-                        />
-                      </label>
-                    </div>
-                    <DeleteIconButton
-                      label={UI_MESSAGES.RESUME_DELETE_QUALIFICATION}
-                      onClick={() => removeRow(index)}
-                    />
-                  </div>
-                </div>
-              );
-            })}
+            {qualifications.map((qualification, index) => (
+              <QualificationRow
+                key={`qualification-${index}`}
+                qualification={qualification}
+                index={index}
+                qualificationNames={qualificationNames}
+                rowDirty={qualificationsDirty?.[index]}
+                focusLocator={focusLocator}
+                onUpdate={updateField}
+                onRemove={removeRow}
+              />
+            ))}
             <button type="button" className={`ghost ${styles.addButton}`} onClick={addRow}>
               <PlusIcon />
               資格を追加

--- a/frontend/src/components/forms/sections/CareerSelfPrSection.tsx
+++ b/frontend/src/components/forms/sections/CareerSelfPrSection.tsx
@@ -1,3 +1,5 @@
+import type { CareerFieldLocator } from "../../../payloadBuilders";
+import { useFocusOnMatch } from "../../../hooks/useFocusOnMatch";
 import shared from "../../../styles/shared.module.css";
 import { DirtyDot } from "../../ui/DirtyDot";
 import { Skeleton } from "../../ui/Skeleton";
@@ -13,13 +15,24 @@ type Props = {
   onChange: (value: string) => void;
   /** 未保存変更があるか */
   dirty?: boolean;
+  /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠用） */
+  focusLocator?: CareerFieldLocator | null;
 };
 
 /**
  * 職務経歴書の「自己PR」セクション。
  * 元 CareerResumeForm の JSX をセクション単位で読みやすくするための切り出し。
  */
-export function CareerSelfPrSection({ selfPr, loading, onChange, dirty = false }: Props) {
+export function CareerSelfPrSection({
+  selfPr,
+  loading,
+  onChange,
+  dirty = false,
+  focusLocator = null,
+}: Props) {
+  const invalid = focusLocator?.kind === "self_pr";
+  const selfPrRef = useFocusOnMatch<HTMLTextAreaElement>(invalid);
+
   return (
     <section className={shared.section}>
       {loading ? (
@@ -32,6 +45,8 @@ export function CareerSelfPrSection({ selfPr, loading, onChange, dirty = false }
           rows={4}
           required
           labelAdornment={<DirtyDot visible={dirty} />}
+          textareaRef={selfPrRef}
+          invalid={invalid}
         />
       )}
     </section>

--- a/frontend/src/components/ui/Collapsible.tsx
+++ b/frontend/src/components/ui/Collapsible.tsx
@@ -12,6 +12,12 @@ type CollapsibleProps = {
   headerActions?: ReactNode;
   /** 見出しの見た目バリアント（section=セクション見出し相当 / entry=エントリ見出し相当） */
   variant?: "section" | "entry";
+  /**
+   * この値が（null/undefined 以外へ）変化したら強制的に開く。
+   * バリデーション失敗時に該当フィールドを含むパネルを自動展開してフォーカスするために使う。
+   * 内部の開閉 state はそのままなので、展開後にユーザーが再度畳むことは可能。
+   */
+  forceOpenKey?: string | number | null;
   /** 折りたたみ対象の中身 */
   children: ReactNode;
 };
@@ -25,9 +31,19 @@ export function Collapsible({
   defaultOpen = true,
   headerActions,
   variant = "section",
+  forceOpenKey,
   children,
 }: CollapsibleProps) {
   const [open, setOpen] = useState(defaultOpen);
+
+  // forceOpenKey が（前回適用値と異なる非 null 値へ）変化したら強制的に開く。
+  // レンダー中に直前の値と比較して setState する React 公式パターン
+  // （useEffect 内で setState するより推奨される）。展開後の再折りたたみは可能。
+  const [appliedForceKey, setAppliedForceKey] = useState<string | number | null>(null);
+  if (forceOpenKey != null && forceOpenKey !== appliedForceKey) {
+    setAppliedForceKey(forceOpenKey);
+    setOpen(true);
+  }
 
   return (
     <div>

--- a/frontend/src/hooks/useFocusOnMatch.test.ts
+++ b/frontend/src/hooks/useFocusOnMatch.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { useFocusOnMatch } from "./useFocusOnMatch";
+
+describe("useFocusOnMatch", () => {
+  it("active=true で要素が渡されるとフォーカスされる", () => {
+    const { result } = renderHook(() => useFocusOnMatch<HTMLInputElement>(true));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    result.current(input);
+
+    expect(document.activeElement).toBe(input);
+    input.remove();
+  });
+
+  it("active=false なら要素が渡されてもフォーカスされない", () => {
+    const { result } = renderHook(() => useFocusOnMatch<HTMLInputElement>(false));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    result.current(input);
+
+    expect(document.activeElement).not.toBe(input);
+    input.remove();
+  });
+
+  it("null が渡されても例外を投げない", () => {
+    const { result } = renderHook(() => useFocusOnMatch<HTMLInputElement>(true));
+    expect(() => result.current(null)).not.toThrow();
+  });
+
+  it("active が false→true に変わるとコールバックの identity が変わる（再アタッチ用）", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useFocusOnMatch<HTMLInputElement>(active),
+      { initialProps: { active: false } },
+    );
+    const first = result.current;
+    rerender({ active: true });
+    expect(result.current).not.toBe(first);
+  });
+});

--- a/frontend/src/hooks/useFocusOnMatch.ts
+++ b/frontend/src/hooks/useFocusOnMatch.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+
+/**
+ * バリデーション失敗時に対象入力へフォーカス＆スクロールするための ref コールバックを返す。
+ *
+ * `active` が true のときに要素がマウント（または ref が再アタッチ）されると、
+ * その要素を画面中央へスクロールしてフォーカスする。`active` が false→true に変わると
+ * useCallback の identity が変わるため React が ref を貼り直し、既存要素にも発火する。
+ *
+ * DOM id + querySelector 方式と違い「折りたたみ展開後」「モーダル mount 後」でも
+ * 要素出現と同時にフォーカスされるため、タイミングずれが起きない。
+ */
+export function useFocusOnMatch<T extends HTMLElement>(active: boolean) {
+  return useCallback(
+    (el: T | null) => {
+      if (el && active) {
+        // scrollIntoView は jsdom 等では未実装のため存在チェックしてから呼ぶ。
+        if (typeof el.scrollIntoView === "function") {
+          el.scrollIntoView({ block: "center", behavior: "smooth" });
+        }
+        el.focus({ preventScroll: true });
+      }
+    },
+    [active],
+  );
+}

--- a/frontend/src/payloadBuilders.test.ts
+++ b/frontend/src/payloadBuilders.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildCareerPayload,
   hasAnyText,
+  validateCareerForm,
   validateDateRange,
   type CareerClientForm,
   type CareerExperienceForm,
@@ -647,5 +648,161 @@ describe("buildCareerPayload (qualifications)", () => {
       }),
     );
     expect(payload.qualifications).toEqual([{ acquired_date: "2024-01-01", name: "基本情報" }]);
+  });
+});
+
+// ── validateCareerForm: locator 付き検証 ─────────────────────────
+
+describe("validateCareerForm (locator)", () => {
+  it("問題が無ければ null を返す", () => {
+    expect(validateCareerForm(baseState())).toBeNull();
+  });
+
+  it("氏名が空なら full_name locator", () => {
+    const result = validateCareerForm(baseState({ full_name: " " }));
+    expect(result?.locator).toEqual({ kind: "full_name" });
+    expect(result?.message).toContain("氏名");
+  });
+
+  it("職務要約が空なら career_summary locator", () => {
+    const result = validateCareerForm(baseState({ career_summary: "" }));
+    expect(result?.locator).toEqual({ kind: "career_summary" });
+  });
+
+  it("自己PR が空なら self_pr locator", () => {
+    const result = validateCareerForm(baseState({ self_pr: "" }));
+    expect(result?.locator).toEqual({ kind: "self_pr" });
+  });
+
+  it("会社名が空なら該当 experience の company locator（元 index 保持）", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [
+          // 1 件目は空欄だけ（除外される）、2 件目で会社名のみ欠落させる。
+          blankExperience({
+            company: "",
+            business_description: "",
+            start_date: "",
+            end_date: "",
+          }),
+          blankExperience({ company: "" }),
+        ],
+      }),
+    );
+    expect(result?.locator).toEqual({ kind: "experience", expIndex: 1, field: "company" });
+  });
+
+  it("離職年月が空なら experience の end_date locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [blankExperience({ is_current: false, end_date: "  " })],
+      }),
+    );
+    expect(result?.locator).toEqual({ kind: "experience", expIndex: 0, field: "end_date" });
+  });
+
+  it("非IT で詳細が空なら experience の description locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [blankExperience({ is_it_company: false, description: "  " })],
+      }),
+    );
+    expect(result?.locator).toEqual({ kind: "experience", expIndex: 0, field: "description" });
+  });
+
+  it("休暇の開始年月が空なら vacation の start_date locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [
+          blankExperience({
+            clients: [
+              blankClient({
+                is_vacation: true,
+                vacation_start_date: "",
+                vacation_description: "育児休暇",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(result?.locator).toEqual({
+      kind: "vacation",
+      expIndex: 0,
+      clientIndex: 0,
+      field: "start_date",
+    });
+  });
+
+  it("プロジェクト期間の開始年月が空なら project の start_date locator（各 index 保持）", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [
+          blankExperience({
+            clients: [
+              blankClient({
+                name: "顧客A",
+                has_client: true,
+                projects: [blankProject({ periods: [blankPeriod({ start_date: "" })] })],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(result?.locator).toEqual({
+      kind: "project",
+      expIndex: 0,
+      clientIndex: 0,
+      projIndex: 0,
+      periodIndex: 0,
+      field: "start_date",
+    });
+  });
+
+  it("プロジェクト期間の終了年月が空なら project の end_date locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        experiences: [
+          blankExperience({
+            clients: [
+              blankClient({
+                name: "顧客A",
+                has_client: true,
+                projects: [
+                  blankProject({ periods: [blankPeriod({ is_current: false, end_date: "" })] }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(result?.locator).toEqual({
+      kind: "project",
+      expIndex: 0,
+      clientIndex: 0,
+      projIndex: 0,
+      periodIndex: 0,
+      field: "end_date",
+    });
+  });
+
+  it("資格の名称が空なら qualification の name locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        qualifications: [{ acquired_date: "2024-01", name: "" }],
+      }),
+    );
+    expect(result?.locator).toEqual({ kind: "qualification", index: 0, field: "name" });
+  });
+
+  it("資格の取得日が空なら qualification の acquired_date locator", () => {
+    const result = validateCareerForm(
+      baseState({
+        qualifications: [{ acquired_date: "", name: "基本情報" }],
+      }),
+    );
+    expect(result?.locator).toEqual({ kind: "qualification", index: 0, field: "acquired_date" });
   });
 });

--- a/frontend/src/payloadBuilders.ts
+++ b/frontend/src/payloadBuilders.ts
@@ -69,6 +69,43 @@ export type CareerFormState = {
   qualifications: ResumeQualificationItem[];
 };
 
+/**
+ * バリデーション失敗フィールドの位置情報。
+ * すべて元の `CareerFormState` の index を指し、保存時のフォーカス・赤枠表示に使う。
+ * プロジェクト配下（project）は `ProjectModal` を開いてから期間入力をフォーカスするため、
+ * exp/client/proj/period の各 index を保持する。
+ */
+export type CareerFieldLocator =
+  | { kind: "full_name" }
+  | { kind: "career_summary" }
+  | { kind: "self_pr" }
+  | {
+      kind: "experience";
+      expIndex: number;
+      field: "company" | "business_description" | "start_date" | "end_date" | "description";
+    }
+  | {
+      kind: "vacation";
+      expIndex: number;
+      clientIndex: number;
+      field: "start_date" | "end_date";
+    }
+  | {
+      kind: "project";
+      expIndex: number;
+      clientIndex: number;
+      projIndex: number;
+      periodIndex: number;
+      field: "start_date" | "end_date";
+    }
+  | { kind: "qualification"; index: number; field: "name" | "acquired_date" };
+
+/** バリデーション結果。エラーが無ければ null。 */
+export type CareerValidationError = {
+  message: string;
+  locator: CareerFieldLocator;
+};
+
 export function hasAnyText(values: Array<string | null | undefined>): boolean {
   return values.some((value) => Boolean(value?.trim()));
 }
@@ -91,6 +128,36 @@ export function validatePeriods(periods: CareerProjectPeriodForm[]): string | nu
     if (err) return err;
   }
   return null;
+}
+
+/**
+ * payload に含める／バリデーション対象とする職務経歴かを判定する。
+ * 会社名・事業内容・開始・終了のいずれかに入力があれば「内容あり」とみなす。
+ * （end_date は在職中なら空として扱い、builder の正規化と基準を揃える）
+ */
+export function experienceIncluded(exp: CareerExperienceForm): boolean {
+  const end = exp.is_current ? "" : exp.end_date;
+  return hasAnyText([exp.company, exp.business_description, exp.start_date, end]);
+}
+
+/** payload に含める／バリデーション対象とするプロジェクトかを判定する。 */
+export function projectIncluded(proj: CareerProjectForm): boolean {
+  return hasAnyText([proj.name, proj.description]);
+}
+
+/**
+ * payload に含める／バリデーション対象とする取引先かを判定する。
+ * 休暇は期間・詳細のいずれかに入力があれば対象。通常取引先は
+ * 「取引先なし」または呼称入力あり、または内容のあるプロジェクトを持つ場合に対象。
+ */
+export function clientIncluded(client: CareerClientForm): boolean {
+  if (client.is_vacation) {
+    const end = client.vacation_is_current ? "" : client.vacation_end_date;
+    return hasAnyText([client.vacation_start_date, end, client.vacation_description]);
+  }
+  const name = client.has_client ? client.name : "";
+  const hasProjects = client.projects.some(projectIncluded);
+  return !client.has_client || Boolean(name.trim()) || hasProjects;
 }
 
 function buildTeam(team: CareerProjectForm["team"]): ProjectTeam {
@@ -144,9 +211,7 @@ function buildClient(client: CareerClientForm): Client {
   return {
     name: client.has_client ? client.name.trim() : "",
     has_client: client.has_client,
-    projects: client.projects
-      .map(buildProject)
-      .filter((p) => hasAnyText([p.name, p.description])),
+    projects: client.projects.filter(projectIncluded).map(buildProject),
     is_vacation: false,
     vacation_start_date: "",
     vacation_end_date: "",
@@ -155,106 +220,193 @@ function buildClient(client: CareerClientForm): Client {
   };
 }
 
-export function buildCareerPayload(state: CareerFormState): ResumeCreate {
-  const full_name = state.full_name.trim();
-  if (!full_name) {
-    throw new Error(VALIDATION_MESSAGES.FULL_NAME_REQUIRED);
+function buildExperience(exp: CareerExperienceForm): Experience {
+  return {
+    company: exp.company.trim(),
+    business_description: exp.business_description.trim(),
+    start_date: exp.start_date.trim(),
+    end_date: exp.is_current ? "" : exp.end_date.trim(),
+    is_current: exp.is_current,
+    employee_count: exp.employee_count.trim(),
+    capital: exp.capital.trim(),
+    capital_unit: exp.capital_unit,
+    is_it_company: exp.is_it_company,
+    description: exp.is_it_company ? "" : exp.description.trim(),
+    clients: exp.is_it_company ? exp.clients.filter(clientIncluded).map(buildClient) : [],
+  };
+}
+
+/**
+ * 職務経歴フォームを走査し、最初に見つかった必須・日付エラーを locator 付きで返す。
+ * エラーが無ければ null。`buildCareerPayload` が投げていた検査をここに集約し、
+ * 保存時のフォーカス・赤枠表示に使えるよう「どのフィールドか」を返す。
+ *
+ * 検査順序とメッセージは従来の `buildCareerPayload` と完全に一致させている
+ * （氏名 → 職務要約 → 自己PR → 職務経歴 → 資格）。index はすべて元フォームのもの。
+ */
+export function validateCareerForm(state: CareerFormState): CareerValidationError | null {
+  if (!state.full_name.trim()) {
+    return { message: VALIDATION_MESSAGES.FULL_NAME_REQUIRED, locator: { kind: "full_name" } };
+  }
+  if (!state.career_summary.trim()) {
+    return {
+      message: VALIDATION_MESSAGES.CAREER_SUMMARY_REQUIRED,
+      locator: { kind: "career_summary" },
+    };
+  }
+  if (!state.self_pr.trim()) {
+    return { message: VALIDATION_MESSAGES.SELF_PR_REQUIRED, locator: { kind: "self_pr" } };
   }
 
-  const career_summary = state.career_summary.trim();
-  if (!career_summary) {
-    throw new Error(VALIDATION_MESSAGES.CAREER_SUMMARY_REQUIRED);
-  }
+  for (let expIndex = 0; expIndex < state.experiences.length; expIndex += 1) {
+    const exp = state.experiences[expIndex];
+    // 空欄だけの経歴は payload から除外されるためバリデーション対象外。
+    if (!experienceIncluded(exp)) continue;
 
-  const self_pr = state.self_pr.trim();
-  if (!self_pr) {
-    throw new Error(VALIDATION_MESSAGES.SELF_PR_REQUIRED);
-  }
+    const company = exp.company.trim();
+    const business = exp.business_description.trim();
+    const start = exp.start_date.trim();
+    const end = exp.is_current ? "" : exp.end_date.trim();
 
-  const experiences: Experience[] = state.experiences
-    .map((exp) => ({
-      company: exp.company.trim(),
-      business_description: exp.business_description.trim(),
-      start_date: exp.start_date.trim(),
-      end_date: exp.is_current ? "" : exp.end_date.trim(),
-      is_current: exp.is_current,
-      employee_count: exp.employee_count.trim(),
-      capital: exp.capital.trim(),
-      capital_unit: exp.capital_unit,
-      is_it_company: exp.is_it_company,
-      description: exp.is_it_company ? "" : exp.description.trim(),
-      clients: exp.is_it_company
-        ? exp.clients
-            .map(buildClient)
-            .filter((c) =>
-              c.is_vacation
-                ? hasAnyText([c.vacation_start_date, c.vacation_end_date, c.vacation_description])
-                : !c.has_client || c.name.trim() || (c.projects ?? []).length > 0,
-            )
-        : [],
-    }))
-    .filter((exp) =>
-      hasAnyText([exp.company, exp.business_description, exp.start_date, exp.end_date]),
-    );
+    if (!company) {
+      return {
+        message: VALIDATION_MESSAGES.EXPERIENCE_REQUIRED_FIELDS,
+        locator: { kind: "experience", expIndex, field: "company" },
+      };
+    }
+    if (!business) {
+      return {
+        message: VALIDATION_MESSAGES.EXPERIENCE_REQUIRED_FIELDS,
+        locator: { kind: "experience", expIndex, field: "business_description" },
+      };
+    }
+    if (!start) {
+      return {
+        message: VALIDATION_MESSAGES.EXPERIENCE_REQUIRED_FIELDS,
+        locator: { kind: "experience", expIndex, field: "start_date" },
+      };
+    }
+    if (!exp.is_current && !end) {
+      return {
+        message: VALIDATION_MESSAGES.EXPERIENCE_END_DATE_REQUIRED,
+        locator: { kind: "experience", expIndex, field: "end_date" },
+      };
+    }
+    if (!exp.is_current && start && end && end < start) {
+      return {
+        message: VALIDATION_MESSAGES.DATE_RANGE_INVALID,
+        locator: { kind: "experience", expIndex, field: "end_date" },
+      };
+    }
 
-  for (const exp of experiences) {
-    if (!exp.company || !exp.business_description || !exp.start_date) {
-      throw new Error(VALIDATION_MESSAGES.EXPERIENCE_REQUIRED_FIELDS);
-    }
-    if (!exp.is_current && !exp.end_date) {
-      throw new Error(VALIDATION_MESSAGES.EXPERIENCE_END_DATE_REQUIRED);
-    }
-    if (!exp.is_current && exp.start_date && exp.end_date && exp.end_date < exp.start_date) {
-      throw new Error(VALIDATION_MESSAGES.DATE_RANGE_INVALID);
-    }
     if (!exp.is_it_company) {
-      if (!exp.description) {
-        throw new Error(VALIDATION_MESSAGES.EXPERIENCE_DESCRIPTION_REQUIRED);
+      if (!exp.description.trim()) {
+        return {
+          message: VALIDATION_MESSAGES.EXPERIENCE_DESCRIPTION_REQUIRED,
+          locator: { kind: "experience", expIndex, field: "description" },
+        };
       }
       continue;
     }
-    for (const client of exp.clients ?? []) {
+
+    for (let clientIndex = 0; clientIndex < exp.clients.length; clientIndex += 1) {
+      const client = exp.clients[clientIndex];
+      if (!clientIncluded(client)) continue;
+
       if (client.is_vacation) {
-        if (!client.vacation_start_date) {
-          throw new Error(VALIDATION_MESSAGES.VACATION_START_DATE_REQUIRED);
+        const vs = client.vacation_start_date.trim();
+        const ve = client.vacation_is_current ? "" : client.vacation_end_date.trim();
+        if (!vs) {
+          return {
+            message: VALIDATION_MESSAGES.VACATION_START_DATE_REQUIRED,
+            locator: { kind: "vacation", expIndex, clientIndex, field: "start_date" },
+          };
         }
-        if (!client.vacation_is_current && !client.vacation_end_date) {
-          throw new Error(VALIDATION_MESSAGES.VACATION_END_DATE_REQUIRED);
+        if (!client.vacation_is_current && !ve) {
+          return {
+            message: VALIDATION_MESSAGES.VACATION_END_DATE_REQUIRED,
+            locator: { kind: "vacation", expIndex, clientIndex, field: "end_date" },
+          };
         }
-        if (
-          !client.vacation_is_current &&
-          client.vacation_start_date &&
-          client.vacation_end_date &&
-          client.vacation_end_date < client.vacation_start_date
-        ) {
-          throw new Error(VALIDATION_MESSAGES.DATE_RANGE_INVALID);
+        if (!client.vacation_is_current && vs && ve && ve < vs) {
+          return {
+            message: VALIDATION_MESSAGES.DATE_RANGE_INVALID,
+            locator: { kind: "vacation", expIndex, clientIndex, field: "end_date" },
+          };
         }
         continue;
       }
-      for (const proj of client.projects ?? []) {
+
+      for (let projIndex = 0; projIndex < client.projects.length; projIndex += 1) {
+        const proj = client.projects[projIndex];
+        if (!projectIncluded(proj)) continue;
+
         // 内容のあるプロジェクトは periods が 1 件以上あり、各期間の開始年月が必須。
-        if ((proj.periods ?? []).length === 0) {
-          throw new Error(VALIDATION_MESSAGES.PROJECT_START_DATE_REQUIRED);
+        if (proj.periods.length === 0) {
+          return {
+            message: VALIDATION_MESSAGES.PROJECT_START_DATE_REQUIRED,
+            locator: { kind: "project", expIndex, clientIndex, projIndex, periodIndex: 0, field: "start_date" },
+          };
         }
-        for (const period of proj.periods ?? []) {
-          if (!period.start_date) {
-            throw new Error(VALIDATION_MESSAGES.PROJECT_START_DATE_REQUIRED);
+        for (let periodIndex = 0; periodIndex < proj.periods.length; periodIndex += 1) {
+          const period = proj.periods[periodIndex];
+          const ps = period.start_date.trim();
+          const pe = period.is_current ? "" : period.end_date.trim();
+          if (!ps) {
+            return {
+              message: VALIDATION_MESSAGES.PROJECT_START_DATE_REQUIRED,
+              locator: { kind: "project", expIndex, clientIndex, projIndex, periodIndex, field: "start_date" },
+            };
           }
-          if (!period.is_current && !period.end_date) {
-            throw new Error(VALIDATION_MESSAGES.PROJECT_END_DATE_REQUIRED);
+          if (!period.is_current && !pe) {
+            return {
+              message: VALIDATION_MESSAGES.PROJECT_END_DATE_REQUIRED,
+              locator: { kind: "project", expIndex, clientIndex, projIndex, periodIndex, field: "end_date" },
+            };
           }
-          if (
-            !period.is_current &&
-            period.start_date &&
-            period.end_date &&
-            period.end_date < period.start_date
-          ) {
-            throw new Error(VALIDATION_MESSAGES.DATE_RANGE_INVALID);
+          if (!period.is_current && ps && pe && pe < ps) {
+            return {
+              message: VALIDATION_MESSAGES.DATE_RANGE_INVALID,
+              locator: { kind: "project", expIndex, clientIndex, projIndex, periodIndex, field: "end_date" },
+            };
           }
         }
       }
     }
   }
+
+  for (let index = 0; index < state.qualifications.length; index += 1) {
+    const q = state.qualifications[index];
+    const acquired = q.acquired_date.trim();
+    const name = q.name.trim();
+    if (!hasAnyText([acquired, name])) continue;
+    if (!acquired) {
+      return {
+        message: VALIDATION_MESSAGES.QUALIFICATION_REQUIRED_FIELDS,
+        locator: { kind: "qualification", index, field: "acquired_date" },
+      };
+    }
+    if (!name) {
+      return {
+        message: VALIDATION_MESSAGES.QUALIFICATION_REQUIRED_FIELDS,
+        locator: { kind: "qualification", index, field: "name" },
+      };
+    }
+  }
+
+  return null;
+}
+
+export function buildCareerPayload(state: CareerFormState): ResumeCreate {
+  // バリデーションは validateCareerForm に集約。失敗時は従来同様メッセージを throw する。
+  const validation = validateCareerForm(state);
+  if (validation) {
+    throw new Error(validation.message);
+  }
+
+  const experiences: Experience[] = state.experiences
+    .filter(experienceIncluded)
+    .map(buildExperience);
 
   const qualifications: ResumeQualificationItem[] = state.qualifications
     .map((q) => ({
@@ -263,16 +415,10 @@ export function buildCareerPayload(state: CareerFormState): ResumeCreate {
     }))
     .filter((q) => hasAnyText([q.acquired_date, q.name]));
 
-  for (const q of qualifications) {
-    if (!q.acquired_date || !q.name) {
-      throw new Error(VALIDATION_MESSAGES.QUALIFICATION_REQUIRED_FIELDS);
-    }
-  }
-
   return {
-    full_name,
-    career_summary,
-    self_pr,
+    full_name: state.full_name.trim(),
+    career_summary: state.career_summary.trim(),
+    self_pr: state.self_pr.trim(),
     experiences,
     qualifications,
   };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -194,6 +194,25 @@ select:focus {
   outline-offset: 1px;
 }
 
+/* バリデーション失敗フィールドの強調（保存時にフォーカスされる入力に付与される） */
+input[aria-invalid="true"],
+textarea[aria-invalid="true"],
+select[aria-invalid="true"] {
+  border-color: var(--error);
+}
+
+input[aria-invalid="true"]:focus,
+textarea[aria-invalid="true"]:focus,
+select[aria-invalid="true"]:focus,
+/* import-assign-form の :focus 緑枠（同詳細度・後勝ち）に負けないよう詳細度を上げる。
+   バリデーション失敗フィールドはフォーカス中でも赤を優先する。 */
+.import-assign-form input[aria-invalid="true"]:focus,
+.import-assign-form textarea[aria-invalid="true"]:focus,
+.import-assign-form select[aria-invalid="true"]:focus {
+  outline-color: var(--error);
+  border-color: var(--error);
+}
+
 button {
   border: none;
   border-radius: 8px;


### PR DESCRIPTION
## 概要

職務経歴書（Resume）の保存ボタン押下時に必須・日付エラーを検出したら、**該当入力欄へ自動フォーカス＋スクロール＋赤枠 (aria-invalid)** で強調するようにしました。プロジェクト配下のエラーは **`ProjectModal` を自動で開いて期間入力にフォーカス**し、折りたたみ (`Collapsible`) が閉じている場合は自動展開します。

これまではエラーメッセージが画面上部に1行出るだけで、長くネストしたフォーム（職務経歴 → 取引先 → プロジェクト → 期間）のどこが問題か手で探す必要がありました。

## 変更点

### バリデーション中核 (`payloadBuilders.ts`)
- 失敗フィールドの位置（`CareerFieldLocator`）＋メッセージを返す **`validateCareerForm`** を新設。`buildCareerPayload` はこれに委譲（**メッセージ契約は不変**、既存テスト維持）。
- 包含判定の述語（`experienceIncluded` / `clientIncluded` / `projectIncluded`）を builder と validator で共用し DRY 化。

### フォーカス基盤
- **`useFocusOnMatch`** フックを追加（要素 mount／一致時にスクロール＋フォーカス。`scrollIntoView` は jsdom 対策で存在チェック）。
- `Collapsible` に `forceOpenKey`（レンダー中比較で自動展開する React 公式パターン）。
- `MarkdownTextarea` / `Combobox` に `ref` ・ `invalid` prop を追加。

### 配線・UX
- `CareerResumeForm` が保存前に `validateCareerForm` → エラーなら `setError` ＋ フォーカス位置をセットし save をスキップ。編集時に赤枠クリア。
- フォームに **`noValidate`** を付与し、必須チェックを `validateCareerForm` に一本化（ブラウザ標準の `required` バブルが独自フォーカス・赤枠・日本語メッセージを横取りするのを防止）。
- `aria-invalid` の赤枠を import-assist の緑フォーカス枠より優先する CSS（詳細度を上げて、フォーカス中でも不正フィールドは赤を優先）。

## 動作確認

`/career` で実機確認（Playwright・API モック）:

1. 空のまま保存 → 氏名欄にフォーカス＋赤枠＋「氏名を入力してください。」
2. プロジェクト期間未入力で保存 → 「プロジェクト編集」ダイアログが自動で開き、開始(必須)に赤枠フォーカス

## テスト

- `validateCareerForm` の locator 検証（top-level / experience / vacation / project / qualification）
- `useFocusOnMatch`（active 切替・null 安全）
- `ProjectModal` の autoFocus
- ローカル CI 相当（ESLint / tsc+vite build / vitest **226件**）すべて green

## 補足

- E2E 必須トリガー（新規ルート/認証/レイアウト/通知ベル）には該当しないため未追加。
- `Collapsible` / `MarkdownTextarea` / `Combobox` への追加 prop はすべて optional で既存利用箇所に影響なし。
- 最新 `main` にリベース済み（コンフリクトは資格セクションのレイアウト刷新と統合解決）。

https://claude.ai/code/session_01WvxsAJjzqnvUMkyHYd4CNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvxsAJjzqnvUMkyHYd4CNd)_