### PR TITLE
feat(career): 未保存時の離脱確認（× 閉じ/リロード）を追加

### DIFF
--- a/frontend/src/components/forms/CareerResumeForm.tsx
+++ b/frontend/src/components/forms/CareerResumeForm.tsx
@@ -18,6 +18,7 @@ import { useImportPanelLayout } from "../../hooks/career/useImportPanelLayout";
 import { useResumeDiffPreview } from "../../hooks/career/useResumeDiffPreview";
 import { useResumeImportAssist } from "../../hooks/career/useResumeImportAssist";
 import { useDocumentForm } from "../../hooks/useDocumentForm";
+import { useUnsavedChangesWarning } from "../../hooks/useUnsavedChangesWarning";
 import { clearCareerDraft, loadCareerDraft, saveCareerDraft } from "../../utils/careerDraft";
 import { buildCareerPayload, validateCareerForm } from "../../payloadBuilders";
 import type { CareerFieldLocator, CareerFormState } from "../../payloadBuilders";
@@ -137,6 +138,13 @@ export function CareerResumeForm({ isAuthenticated }: { isAuthenticated: boolean
 
   /** 未保存マーク（🔴）の表示判定に使う dirty マップ */
   const dirty = useCareerDirty(form, baseline);
+
+  /**
+   * ログイン済みで未保存の変更があるとき、× 閉じ / リロード時にブラウザ標準の離脱確認を出す。
+   * formCache は redux-persist の blacklist のためリロードで消える。未保存編集の消失を防ぐ。
+   * 未ログインは baseline が null で dirty.any が常に false（＝対象外）。入力は sessionStorage に自動退避される。
+   */
+  useUnsavedChangesWarning(isAuthenticated && dirty.any);
 
   /**
    * baseline（保存済み）と form（編集中）の変更点リスト。左右 diff モーダルのサイドバーと

--- a/frontend/src/hooks/useUnsavedChangesWarning.test.ts
+++ b/frontend/src/hooks/useUnsavedChangesWarning.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { useUnsavedChangesWarning } from "./useUnsavedChangesWarning";
+
+/** beforeunload を dispatch し、ハンドラが preventDefault したか（defaultPrevented）を返す。 */
+function dispatchBeforeUnload(): boolean {
+  const event = new Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe("useUnsavedChangesWarning", () => {
+  it("when=true の間は beforeunload を抑止する（離脱確認を出す）", () => {
+    renderHook(() => useUnsavedChangesWarning(true));
+    expect(dispatchBeforeUnload()).toBe(true);
+  });
+
+  it("when=false なら beforeunload を抑止しない（リスナ未登録）", () => {
+    renderHook(() => useUnsavedChangesWarning(false));
+    expect(dispatchBeforeUnload()).toBe(false);
+  });
+
+  it("アンマウント後はリスナを解除する", () => {
+    const { unmount } = renderHook(() => useUnsavedChangesWarning(true));
+    unmount();
+    expect(dispatchBeforeUnload()).toBe(false);
+  });
+
+  it("when が true→false に変わるとリスナを解除する", () => {
+    const { rerender } = renderHook(
+      ({ when }: { when: boolean }) => useUnsavedChangesWarning(when),
+      { initialProps: { when: true } },
+    );
+    expect(dispatchBeforeUnload()).toBe(true);
+    rerender({ when: false });
+    expect(dispatchBeforeUnload()).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useUnsavedChangesWarning.ts
+++ b/frontend/src/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+/**
+ * 未保存の変更があるとき、× 閉じ / リロード時にブラウザ標準の離脱確認ダイアログを出すフック。
+ *
+ * `when` が true の間だけ `beforeunload` リスナを登録し、`preventDefault()` で
+ * ブラウザ標準の「このサイトを離れますか？」確認を発火させる。
+ *
+ * 注意:
+ * - SPA 内のアプリ内ページ遷移では `beforeunload` は発火しない（ドキュメントの
+ *   アンロード時＝× 閉じ・リロード・別 URL への遷移時のみ）。アプリ内遷移のガードには使えない。
+ * - 表示文言はブラウザが管理しており JS から上書きできない（`returnValue` の文字列は無視される）。
+ */
+export function useUnsavedChangesWarning(when: boolean): void {
+  useEffect(() => {
+    if (!when) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // 一部の古いブラウザは preventDefault だけでは確認を出さないため returnValue も設定する。
+      // 文字列の中身はブラウザ管理で表示には使われない（空文字で十分）。
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [when]);
+}


### PR DESCRIPTION
## 概要

ログイン済みユーザーが職務経歴書を未保存のまま **× 閉じ / リロード** した際に、ブラウザ標準の離脱確認ダイアログを出して編集内容の消失を防ぎます。

`formCache` は redux-persist の blacklist（PII 保護）のためリロードで消える設計です。そのためログイン済み未保存編集はリロード/× 閉じで失われるため、その経路をガードします。

## 変更内容

- **`useUnsavedChangesWarning` フックを追加**: `when` が true の間だけ `beforeunload` リスナを登録し、`preventDefault()` でブラウザ標準確認を発火する汎用フック。
- **`CareerResumeForm`**: 既存の `dirty.any`（`useCareerDirty`）を再利用し、`useUnsavedChangesWarning(isAuthenticated && dirty.any)` を追加。
- ユニットテスト 4 ケース（true 抑止 / false 非抑止 / アンマウント解除 / true→false 解除）。

## 仕様上の制約（設計判断）

ブラウザ仕様上 `beforeunload` ではカスタム UI・保存処理・文言上書きができないため、**ブラウザ標準ダイアログのみ**（保存する/保存しない の選択や保存後離脱は不可）。表示文言はブラウザ管理のため `messages.ts` 追加なし。

## 対象外（データ消失が起きない経路）

- **未ログインのお試し入力**: `sessionStorage` に自動退避されリロードで復元されるため対象外（`baseline=null` で `dirty.any` も常に false）。
- **アプリ内ページ遷移**: Redux キャッシュで保持され遷移してもデータは残るため対象外（`beforeunload` も発火しない）。

## 検証

- `make test-frontend` … 293 pass
- `make lint-frontend` / `make lint-frontend-messages` … clean
- `make build-frontend` … 型エラーなし
- E2E: `beforeunload` ネイティブダイアログは Playwright で安定検証できないため新規 E2E は追加なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser confirmation warning that appears when users attempt to leave the page with unsaved changes in the career resume form while authenticated.

* **Tests**
  * Added test suite covering unsaved changes warning behavior, including listener registration, cleanup, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->