### PR TITLE
refactor(xr): 通知 DTO を生成型に一本化しエラーコード同期を機械検知する

### DIFF
--- a/backend/tests/test_error_code_sync.py
+++ b/backend/tests/test_error_code_sync.py
@@ -1,0 +1,54 @@
+"""BE の ``ErrorCode`` enum と FE の ``ERROR_CODES`` の集合一致を検証するテスト。
+
+エラーコードは OpenAPI のスキーマに enum 値として乗らないため codegen で同期できず、
+``backend/app/core/errors.py:ErrorCode``（正本）と
+``frontend/src/constants/errorCodes.ts:ERROR_CODES`` を手動同期している。
+片方だけ追加・削除すると FE で未知コードが ``INTERNAL_ERROR`` にサイレント fallback して
+適切なメッセージ・recovery action が出なくなるため、ズレを CI で検知する。
+"""
+
+import re
+from pathlib import Path
+
+from app.core.errors import ErrorCode
+
+# backend/tests/ から見たリポジトリルート（monorepo 前提で frontend が隣接する）
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ERROR_CODES_TS = _REPO_ROOT / "frontend" / "src" / "constants" / "errorCodes.ts"
+
+# `export const ERROR_CODES = [ ... ] as const;` のブロックを取り出す
+_ARRAY_BLOCK = re.compile(r"ERROR_CODES\s*=\s*\[(.*?)\]\s*as\s+const", re.DOTALL)
+# ブロック内の "FOO_BAR" 形式の文字列リテラル
+_CODE_LITERAL = re.compile(r'"([A-Z_]+)"')
+
+
+def _parse_frontend_error_codes() -> set[str]:
+    """FE の ``errorCodes.ts`` から ``ERROR_CODES`` の値集合を抽出する。"""
+    assert _ERROR_CODES_TS.exists(), (
+        f"FE のエラーコード定義が見つからない: {_ERROR_CODES_TS}"
+    )
+    source = _ERROR_CODES_TS.read_text(encoding="utf-8")
+    match = _ARRAY_BLOCK.search(source)
+    assert match is not None, (
+        "errorCodes.ts に `ERROR_CODES = [...] as const` ブロックが見つからない"
+        "（定義形式が変わった場合は本テストのパーサも更新すること）"
+    )
+    return set(_CODE_LITERAL.findall(match.group(1)))
+
+
+def test_error_codes_match_backend_enum() -> None:
+    """BE ``ErrorCode`` と FE ``ERROR_CODES`` の値集合が完全一致すること。"""
+    backend_codes = {code.value for code in ErrorCode}
+    frontend_codes = _parse_frontend_error_codes()
+
+    missing_in_frontend = backend_codes - frontend_codes
+    extra_in_frontend = frontend_codes - backend_codes
+
+    assert not missing_in_frontend, (
+        "BE に存在するが FE 未定義のエラーコード（errorCodes.ts / errorMessages.ts へ追加が必要）: "
+        f"{sorted(missing_in_frontend)}"
+    )
+    assert not extra_in_frontend, (
+        "FE に存在するが BE 未定義のエラーコード（errors.py へ追加、または FE から削除が必要）: "
+        f"{sorted(extra_in_frontend)}"
+    )

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,25 +1,25 @@
 import { request } from "./client";
 import { PATHS } from "./paths";
+import type {
+  MarkAllReadResponse,
+  NotificationResponse,
+  UnreadCountResponse,
+} from "./types";
 
-export interface Notification {
-  id: string;
-  task_type: string;
-  status: "completed" | "failed";
-  title: string;
-  message: string | null;
-  is_read: boolean;
-  created_at: string;
-}
+export type { UnreadCountResponse } from "./types";
 
-export interface UnreadCountResponse {
-  count: number;
-}
+/**
+ * 通知 1 件の型。DTO の正本は backend `routers/notifications.py:NotificationResponse`
+ * （OpenAPI 経由で `api/types.ts` に再エクスポート、ADR-0007）。
+ * 呼び出し側の歴史的な `Notification` 名を保つためのエイリアス。
+ */
+export type Notification = NotificationResponse;
 
 /**
  * 最新30件の通知を取得します。
  */
-export function getNotifications(): Promise<Notification[]> {
-  return request<Notification[]>(PATHS.notifications.base);
+export function getNotifications(): Promise<NotificationResponse[]> {
+  return request<NotificationResponse[]>(PATHS.notifications.base);
 }
 
 /**
@@ -32,8 +32,8 @@ export function getUnreadCount(): Promise<UnreadCountResponse> {
 /**
  * 指定された通知を既読にします。
  */
-export function markAsRead(notificationId: string): Promise<Notification> {
-  return request<Notification>(PATHS.notifications.read(notificationId), {
+export function markAsRead(notificationId: string): Promise<NotificationResponse> {
+  return request<NotificationResponse>(PATHS.notifications.read(notificationId), {
     method: "PATCH",
   });
 }
@@ -41,8 +41,8 @@ export function markAsRead(notificationId: string): Promise<Notification> {
 /**
  * 全通知を既読にします。
  */
-export function markAllAsRead(): Promise<{ updated: number }> {
-  return request<{ updated: number }>(PATHS.notifications.readAll, {
+export function markAllAsRead(): Promise<MarkAllReadResponse> {
+  return request<MarkAllReadResponse>(PATHS.notifications.readAll, {
     method: "POST",
   });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -107,3 +107,14 @@ export type BlogAccountResponse = Schemas["BlogAccountResponse"];
 
 /** ブログ記事。backend `schemas/blog.py:BlogArticleResponse`。 */
 export type BlogArticleResponse = Schemas["BlogArticleResponse"];
+
+// ── 通知（routers/notifications.py）───────────────────────────────────────
+
+/** 通知 1 件。backend `routers/notifications.py:NotificationResponse`。 */
+export type NotificationResponse = Schemas["NotificationResponse"];
+
+/** 未読件数レスポンス。backend `routers/notifications.py:UnreadCountResponse`。 */
+export type UnreadCountResponse = Schemas["UnreadCountResponse"];
+
+/** 全件既読レスポンス。backend `routers/notifications.py:MarkAllReadResponse`。 */
+export type MarkAllReadResponse = Schemas["MarkAllReadResponse"];


### PR DESCRIPTION
## 概要

領域横断（XR）レビュー（`report/XR_report_20260609_2034.md`）の High + Medium を適用。通知 DTO の二重管理を解消し、エラーコードの BE↔FE 同期を機械検知するガードを追加する。

## 変更内容

### High — 通知 DTO を生成型に一本化
- 手書きの `interface Notification` / `interface UnreadCountResponse` と インライン `{ updated: number }` を削除（`status` を誤って `"completed" | "failed"` に狭めていた）
- OpenAPI 生成型（`api/generated.ts`）を `api/types.ts` 経由で再エクスポートし、backend Pydantic schema を唯一の正本に統合（ADR-0007 の既存ミラー規約に合流）
- 呼び出し側（`useNotifications` / `NotificationBell` / テスト）は `export type Notification = NotificationResponse` のエイリアスで **import 変更ゼロ**で互換維持。`status` は union → `string` に広がるが文字列比較のみのため型エラーなし、runtime 挙動も不変

### Medium — エラーコード同期の機械検知
- `backend/tests/test_error_code_sync.py` を追加。FE `errorCodes.ts:ERROR_CODES` をパースし `core/errors.py:ErrorCode` の値集合と完全一致を assert
- OpenAPI は enum 値を運ばず codegen で同期できないため、片側だけ追加・削除すると FE で `INTERNAL_ERROR` にサイレント fallback する穴を CI で塞ぐ

## 破壊的変更
なし（純粋な型 refactor + テスト追加。API 契約・env・依存追加なし）

## 検証
- `make test-backend`: ✅ 403 passed（新規テスト含む）
- `make lint-frontend` / `make test-frontend`（297）/ `make build-frontend`: ✅
- E2E（Playwright）: ✅ 30 passed（通知ベル 5 シナリオ含む。サイドバー要素のため E2E トリガー該当）
- `make dupe-check`: 77 → 77（新規重複なし）

## Follow-ups
- `ai-resume.ts` の型群は backend 未実装で対応相手なし。BE 実装で OpenAPI に乗れば再エクスポートへ移行可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)