### PR TITLE
fix(backend): GitHub OAuth state をサーバー側 Cookie で検証

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,6 +86,18 @@ make ci
 nix develop --command bash -c "cd frontend && npm run test:e2e"
 ```
 
+### SSoT 生成物（codegen）のトリガー — 必須
+
+**SSoT（正本）から自動生成される成果物に影響する変更をしたら、生成物の再生成とコミットは必須。** 正本だけ直して生成物を更新し忘れると、CI の drift チェックで必ず落ちる（コミット段階で気づけず手戻りになる）。
+
+| 正本（変更したら） | 再生成コマンド | コミットすべき生成物 | CI ジョブ |
+|---|---|---|---|
+| backend の OpenAPI スキーマ（`app/schemas/` の Pydantic、router のシグネチャ・query/path パラメータ・**endpoint/schema の docstring**） | `make codegen-types` | `frontend/src/api/generated.ts`（`backend/openapi.json` は gitignore で対象外） | `codegen-drift`（ADR-0007） |
+
+- **判定基準**: 「OpenAPI スペックに出るものを変えたか」。エンドポイントの追加・削除、リクエスト/レスポンス型の変更、query/path パラメータの増減はもちろん、**docstring の文言変更だけでも description として spec に反映される**ため再生成が要る（今回の codegen-drift はこれで発生）。
+- backend の `app/schemas/` / `app/routers/` を触ったら、`make ci` 前に `make codegen-types` を回して `git diff frontend/src/api/generated.ts` を確認する。差分が出たら必ず同じ PR でコミットする。
+- 新しい SSoT→生成物の系統を追加した場合は、本表に行を足して再発防止の対象に含める。
+
 CI 定義: `.github/workflows/ci.yml`
 
 ## 作業開始時のブランチ運用（デフォルト）

--- a/backend/app/routers/auth/endpoints.py
+++ b/backend/app/routers/auth/endpoints.py
@@ -211,6 +211,9 @@ async def github_callback_redirect(
     """
     frontend_url = resolve_frontend_url_from_cookie(None)
 
+    # 成否いずれの経路でも state Cookie を破棄するため、レスポンスを 1 変数に集約する。
+    # 既定は成功用のリダイレクト。照合・トークン交換でエラーになれば except で差し替える。
+    response = _build_callback_html_response(frontend_url)
     try:
         if not code:
             raise_app_error(
@@ -224,16 +227,15 @@ async def github_callback_redirect(
         callback_base = get_callback_base_url() or build_external_base_url(request)
         redirect_uri = f"{callback_base}/auth/github/callback"
         token_response = await authenticate_github_user(db, code, redirect_uri)
+        set_auth_cookies(response, token_response.username, db)
     except HTTPException as error:
         # error.detail は AppErrorResponse の dict 形式なので message フィールドを取り出す
         detail = error.detail
         error_message = detail.get("message") if isinstance(detail, dict) else str(detail)
-        return _build_callback_html_response(frontend_url, error_message=error_message)
-
-    response = _build_callback_html_response(frontend_url)
-    set_auth_cookies(response, token_response.username, db)
-    # 照合済みの state Cookie を破棄（使い捨て・リプレイ防止）
-    delete_oauth_state_cookie(response)
+        response = _build_callback_html_response(frontend_url, error_message=error_message)
+    finally:
+        # 使い捨ての state Cookie は成否に関わらず破棄し、リプレイ窓を残さない
+        delete_oauth_state_cookie(response)
     return response
 
 

--- a/backend/app/routers/auth/endpoints.py
+++ b/backend/app/routers/auth/endpoints.py
@@ -31,11 +31,15 @@ from .oauth_flow import (
     get_frontend_origin,
     resolve_frontend_url_from_cookie,
     resolve_frontend_url_from_request,
+    validate_github_oauth_state,
 )
 from .token_manager import (
     clear_auth_cookies,
+    delete_oauth_state_cookie,
     extract_refresh_token_from_session,
+    read_oauth_state_cookie,
     set_auth_cookies,
+    set_oauth_state_cookie,
 )
 
 # GitHub OAuth Callback URL のパス
@@ -146,14 +150,17 @@ def me(request: Request, current_user=Depends(get_current_user)) -> TokenRespons
 @limiter.limit("10/minute")
 def github_login_url(
     request: Request,
+    response: Response,
     return_to: str | None = None,
 ) -> GitHubLoginUrlResponse:
     """GitHub OAuth 認可 URL と state を返す。
 
-    state はフロントが sessionStorage に保持し、コールバック時に CSRF 検証する。
+    state は HttpOnly Cookie に保存し、コールバックでサーバー側照合する（CSRF 対策の正本）。
+    レスポンスの state はフロントの sessionStorage 照合（多層防御）にも併用する。
     """
     frontend_url = resolve_frontend_url_from_request(request, return_to)
     authorization_url, state = begin_github_oauth(request, frontend_url)
+    set_oauth_state_cookie(response, state)
     return GitHubLoginUrlResponse(authorization_url=authorization_url, state=state)
 
 
@@ -165,8 +172,11 @@ def github_login(
 ) -> RedirectResponse:
     """GitHub OAuth 認可 URL へリダイレクトする。"""
     frontend_url = resolve_frontend_url_from_request(request, return_to)
-    authorization_url, _state = begin_github_oauth(request, frontend_url)
-    return RedirectResponse(url=authorization_url, status_code=status.HTTP_303_SEE_OTHER)
+    authorization_url, state = begin_github_oauth(request, frontend_url)
+    redirect = RedirectResponse(url=authorization_url, status_code=status.HTTP_303_SEE_OTHER)
+    # state を Cookie に保存し、コールバックでサーバー側照合する（CSRF 対策）
+    set_oauth_state_cookie(redirect, state)
+    return redirect
 
 
 def _build_callback_html_response(
@@ -188,17 +198,17 @@ def _build_callback_html_response(
 async def github_callback_redirect(
     request: Request,
     code: str | None = None,
+    state: str | None = None,
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
     """GitHub OAuth コールバックを処理し、フロントエンドへリダイレクトする。
 
     一部の CDN / リバースプロキシは 303 レスポンスの Set-Cookie を除去することがあるため、
     200 + HTML リダイレクトで Cookie を確実にセットする。
-    """
 
-    # 現行フローでは GitHub のリダイレクト先はフロントの /github/callback（React ルート）であり、
-    # フロントが sessionStorage の state を検証してから POST /auth/github/callback でトークン交換する。
-    # このエンドポイントは後方互換のために残しているが、state のサーバー側検証は行わない。
+    state は認可開始時に発行した HttpOnly Cookie とサーバー側で照合する（CSRF 対策）。
+    照合失敗時はトークン交換に進まず、エラー付きでフロントへリダイレクトする。
+    """
     frontend_url = resolve_frontend_url_from_cookie(None)
 
     try:
@@ -209,6 +219,8 @@ async def github_callback_redirect(
                 message=get_error("auth.github_code_missing"),
                 action="GitHub ログインをやり直してください",
             )
+        # CSRF 対策: 認可開始時に発行した state Cookie とコールバックの state を照合する
+        validate_github_oauth_state(read_oauth_state_cookie(request), state)
         callback_base = get_callback_base_url() or build_external_base_url(request)
         redirect_uri = f"{callback_base}/auth/github/callback"
         token_response = await authenticate_github_user(db, code, redirect_uri)
@@ -220,6 +232,8 @@ async def github_callback_redirect(
 
     response = _build_callback_html_response(frontend_url)
     set_auth_cookies(response, token_response.username, db)
+    # 照合済みの state Cookie を破棄（使い捨て・リプレイ防止）
+    delete_oauth_state_cookie(response)
     return response
 
 
@@ -233,12 +247,18 @@ async def github_callback(
 ) -> TokenResponse:
     """GitHub OAuth コードを受け取り、認証 Cookie を発行する。
 
-    state はフロントの sessionStorage で検証済みのためサーバー側では再検証しない。
+    state は認可開始時に発行した HttpOnly Cookie とサーバー側で照合する（CSRF 対策）。
+    フロントの sessionStorage 照合に依存せず API 直叩きのログイン CSRF を防ぐ。
     redirect_uri は GitHub OAuth App の登録値 (`/github/callback`) と一致させる必要がある。
     """
+    # CSRF 対策: Cookie の state と body の state を照合（欠落・不一致は 401）
+    validate_github_oauth_state(read_oauth_state_cookie(request), payload.state)
+
     frontend_url = resolve_frontend_url_from_request(request)
     callback_base = get_callback_base_url() or get_frontend_origin(frontend_url)
     redirect_uri = f"{callback_base}{GITHUB_CALLBACK_PATH}"
     token_response = await authenticate_github_user(db, payload.code, redirect_uri)
     set_auth_cookies(response, token_response.username, db)
+    # 照合済みの state Cookie を破棄（使い捨て・リプレイ防止）
+    delete_oauth_state_cookie(response)
     return token_response

--- a/backend/app/routers/auth/oauth_flow.py
+++ b/backend/app/routers/auth/oauth_flow.py
@@ -206,7 +206,9 @@ def begin_github_oauth(
     """
     GitHub OAuth フローを開始する。
 
-    state は Cookie に保存せず、呼び出し側でフロント (sessionStorage) に渡す。
+    state を生成して返す。呼び出し側（router）が HttpOnly Cookie に保存し、
+    コールバックでサーバー側照合する（CSRF 対策の正本）。フロントの sessionStorage
+    照合は多層防御として併用する。
     コールバック URL は `/github/callback` (フロントの React ルート) に揃える。
     CALLBACK_BASE_URL が設定されている場合は redirect_uri を固定し、
     未設定の場合は frontend_url のオリジンからフォールバックする。

--- a/backend/app/routers/auth/token_manager.py
+++ b/backend/app/routers/auth/token_manager.py
@@ -20,8 +20,16 @@ from ...repositories import UserRepository
 
 logger = logging.getLogger(__name__)
 
-# 認証セッション Cookie 名（state と redirect_url はフロントの sessionStorage で管理する）
+# 認証セッション Cookie 名（access/refresh token を JSON でまとめて保持する）
 GITHUB_OAUTH_SESSION_COOKIE = "session"
+
+# GitHub OAuth state Cookie 名。
+# CSRF 対策として認可開始時にサーバーが発行し、コールバックでサーバー側照合する。
+# フロントの sessionStorage 照合は多層防御として併用するが、正本はこの HttpOnly Cookie。
+GITHUB_OAUTH_STATE_COOKIE = "oauth_state"
+
+# state Cookie の有効期間（秒）。認可開始からコールバック完了までの猶予。
+_OAUTH_STATE_COOKIE_MAX_AGE = 600
 
 
 def extract_refresh_token_from_session(request: Request) -> str | None:
@@ -61,6 +69,24 @@ def delete_cookie(response: Response, key: str, path: str = "/") -> None:
     """指定したキーの Cookie を削除する。"""
     response.delete_cookie(key=key, path=path)
 
+
+
+def set_oauth_state_cookie(response: Response, state: str) -> None:
+    """GitHub OAuth の state を HttpOnly Cookie に保存する。
+
+    コールバック時に Cookie 値と provided state をサーバー側で照合し、CSRF を防ぐ。
+    """
+    set_cookie(response, GITHUB_OAUTH_STATE_COOKIE, state, _OAUTH_STATE_COOKIE_MAX_AGE)
+
+
+def read_oauth_state_cookie(request: Request) -> str | None:
+    """リクエストの Cookie から GitHub OAuth state を取り出す。未設定なら ``None``。"""
+    return request.cookies.get(GITHUB_OAUTH_STATE_COOKIE)
+
+
+def delete_oauth_state_cookie(response: Response) -> None:
+    """GitHub OAuth state Cookie を削除する（照合後の使い捨て・リプレイ防止）。"""
+    delete_cookie(response, GITHUB_OAUTH_STATE_COOKIE, path="/")
 
 
 def set_auth_cookies(response: Response, username: str, db: Session) -> None:

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -21,7 +21,8 @@ class GitHubCallbackRequest(BaseModel):
 class GitHubLoginUrlResponse(BaseModel):
     """GitHub OAuth 認可 URL と CSRF 検証用 state を返すレスポンス。
 
-    state はフロントが sessionStorage に保持し、コールバック時に CSRF 検証する。
+    state はサーバー側で HttpOnly Cookie に保存され、コールバックで照合される（正本）。
+    レスポンスの state はフロントの sessionStorage 照合（多層防御）にも併用する。
     """
 
     authorization_url: str

--- a/backend/tests/auth/test_oauth_flow.py
+++ b/backend/tests/auth/test_oauth_flow.py
@@ -34,6 +34,19 @@ def _seed_oauth_state(client, state: str) -> None:
     client.cookies.set(GITHUB_OAUTH_STATE_COOKIE, state)
 
 
+def _find_set_cookie(response, name: str) -> str:
+    """レスポンスの Set-Cookie 群から指定 Cookie 名のヘッダ 1 行を返す（無ければ ""）。
+
+    複数 Cookie がマージされた文字列ではなく個別エントリで検証したい時に使う
+    （他 Cookie の属性を誤って拾わないため）。
+    """
+    prefix = f"{name}="
+    for key, value in response.headers.multi_items():
+        if key.lower() == "set-cookie" and value.startswith(prefix):
+            return value
+    return ""
+
+
 # ── state 検証テスト ─────────────────────────────────────────────────────
 
 
@@ -160,10 +173,13 @@ def test_github_login_url_returns_state(client) -> None:
     assert "https://github.com/login/oauth/authorize" in data["authorization_url"]
     assert isinstance(data["state"], str)
     assert len(data["state"]) > 0
-    # state はサーバー側の HttpOnly Cookie にも保存される（CSRF 照合の正本）
-    set_cookie = response.headers.get("set-cookie", "")
-    assert f"{GITHUB_OAUTH_STATE_COOKIE}=" in set_cookie
-    assert "HttpOnly" in set_cookie
+    # state はサーバー側の HttpOnly Cookie にも保存される（CSRF 照合の正本）。
+    # Cookie 値が JSON で返した state と一致していることまで確認する。
+    state_cookie = _find_set_cookie(response, GITHUB_OAUTH_STATE_COOKIE)
+    assert state_cookie, "state Cookie が Set-Cookie に存在すること"
+    assert "HttpOnly" in state_cookie
+    cookie_value = state_cookie[len(f"{GITHUB_OAUTH_STATE_COOKIE}=") :].split(";", 1)[0].strip('"')
+    assert cookie_value == data["state"]
     # /auth/** rewrite を回避するため redirect_uri は /github/callback でなければならない
     parsed = urlparse(data["authorization_url"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
@@ -279,6 +295,10 @@ def test_github_callback_redirect_sets_auth_cookie(client) -> None:
     # 200 + HTML リダイレクト: フロントエンド URL が HTML 本文に含まれていることを確認する
     assert "localhost:8788" in response.text
     assert "access_token=" in response.headers["set-cookie"]
+    # 使い捨ての state Cookie が Max-Age=0 で破棄されること（リプレイ防止）
+    state_cookie = _find_set_cookie(response, GITHUB_OAUTH_STATE_COOKIE)
+    assert state_cookie, "state Cookie の削除 Set-Cookie が存在すること"
+    assert "max-age=0" in state_cookie.lower()
 
 
 def test_github_callback_redirect_rejects_mismatched_state(client) -> None:
@@ -300,6 +320,10 @@ def test_github_callback_redirect_rejects_mismatched_state(client) -> None:
     assert "github_error=" in response.text
     # 認証 Cookie は発行されない
     assert "access_token=" not in response.headers.get("set-cookie", "")
+    # 失敗経路でも state Cookie は Max-Age=0 で破棄され、リプレイ窓を残さない
+    state_cookie = _find_set_cookie(response, GITHUB_OAUTH_STATE_COOKIE)
+    assert state_cookie, "state Cookie の削除 Set-Cookie が存在すること"
+    assert "max-age=0" in state_cookie.lower()
 
 
 def test_github_callback_post_rejects_missing_state_cookie(client) -> None:
@@ -378,10 +402,11 @@ def test_github_callback_post_succeeds_with_matching_state(client) -> None:
     # username に "github:" プレフィックスを付けない（素の login 名で保存する）
     assert response.json()["username"] == "octo-post"
     assert response.json()["is_github_user"] is True
-    all_set_cookie = response.headers["set-cookie"]
-    assert "access_token=" in all_set_cookie
-    # 照合済みの state Cookie が Max-Age=0 で破棄されること
-    assert f"{GITHUB_OAUTH_STATE_COOKIE}=" in all_set_cookie
+    assert "access_token=" in response.headers["set-cookie"]
+    # 照合済みの state Cookie が Max-Age=0 で破棄されること（リプレイ防止）
+    state_cookie = _find_set_cookie(response, GITHUB_OAUTH_STATE_COOKIE)
+    assert state_cookie, "state Cookie の削除 Set-Cookie が存在すること"
+    assert "max-age=0" in state_cookie.lower()
     # GitHub への redirect_uri も /github/callback でトークン交換していることを確認する
     posted_kwargs = mock_http.post.call_args.kwargs
     assert posted_kwargs["json"]["redirect_uri"].endswith("/github/callback")

--- a/backend/tests/auth/test_oauth_flow.py
+++ b/backend/tests/auth/test_oauth_flow.py
@@ -21,7 +21,18 @@ from app.routers.auth.oauth_flow import (
     resolve_frontend_url_from_cookie,
     validate_github_oauth_state,
 )
+from app.routers.auth.token_manager import GITHUB_OAUTH_STATE_COOKIE
 from fastapi import HTTPException
+
+
+def _seed_oauth_state(client, state: str) -> None:
+    """認可開始で発行される state Cookie を擬似的にセットする。
+
+    TestClient は Secure Cookie を http で再送しないため、ラウンドトリップではなく
+    手動セットで state Cookie を用意する（conftest の auth_header と同じ方式）。
+    """
+    client.cookies.set(GITHUB_OAUTH_STATE_COOKIE, state)
+
 
 # ── state 検証テスト ─────────────────────────────────────────────────────
 
@@ -147,9 +158,12 @@ def test_github_login_url_returns_state(client) -> None:
     assert response.status_code == 200
     data = response.json()
     assert "https://github.com/login/oauth/authorize" in data["authorization_url"]
-    # state はフロントの sessionStorage に保存して CSRF 検証する
     assert isinstance(data["state"], str)
     assert len(data["state"]) > 0
+    # state はサーバー側の HttpOnly Cookie にも保存される（CSRF 照合の正本）
+    set_cookie = response.headers.get("set-cookie", "")
+    assert f"{GITHUB_OAUTH_STATE_COOKIE}=" in set_cookie
+    assert "HttpOnly" in set_cookie
     # /auth/** rewrite を回避するため redirect_uri は /github/callback でなければならない
     parsed = urlparse(data["authorization_url"])
     redirect_uri = parse_qs(parsed.query)["redirect_uri"][0]
@@ -236,15 +250,17 @@ def test_github_callback_redirect_returns_error_when_code_missing(client) -> Non
 
 
 def test_github_callback_redirect_sets_auth_cookie(client) -> None:
-    """GET /auth/github/callback は code を受け取って認証 Cookie を発行し、デフォルトフロントへリダイレクトする。
+    """GET /auth/github/callback は state 照合に成功すると認証 Cookie を発行する。
 
-    state 検証と redirect URL の cookie 読み出しはフロント (sessionStorage) に移譲したため、
-    リダイレクト先はサーバー側の CORS_ORIGINS[0] にフォールバックする。
+    認可開始時に発行された state Cookie とコールバックの state query が一致する場合のみ
+    トークン交換に進み、デフォルトフロント (CORS_ORIGINS[0]) へリダイレクトする。
     """
     token_response = MagicMock()
     token_response.json.return_value = {"access_token": "github-access-token"}
     user_response = MagicMock()
     user_response.json.return_value = {"id": 12345, "login": "octocat"}
+
+    _seed_oauth_state(client, "valid-state")
 
     with patch("httpx.AsyncClient") as mock_cls:
         mock_http = AsyncMock()
@@ -255,7 +271,7 @@ def test_github_callback_redirect_sets_auth_cookie(client) -> None:
         mock_cls.return_value = mock_http
 
         response = client.get(
-            "/auth/github/callback?code=test-code",
+            "/auth/github/callback?code=test-code&state=valid-state",
             follow_redirects=False,
         )
 
@@ -265,17 +281,81 @@ def test_github_callback_redirect_sets_auth_cookie(client) -> None:
     assert "access_token=" in response.headers["set-cookie"]
 
 
-def test_github_callback_post_does_not_require_cookie(client) -> None:
-    """POST /auth/github/callback は Cookie の state を検証せずトークン交換に進むことを確認する。
+def test_github_callback_redirect_rejects_mismatched_state(client) -> None:
+    """GET /auth/github/callback は state 不一致だとトークン交換せずエラーへリダイレクトする。
 
-    state はフロントの sessionStorage で検証済みのためサーバー側では Cookie を見ない。
+    Cookie の state と query の state が食い違う場合、外部 API を一切叩かず CSRF を防ぐ。
+    """
+    _seed_oauth_state(client, "real-state")
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+        response = client.get(
+            "/auth/github/callback?code=test-code&state=attacker-state",
+            follow_redirects=False,
+        )
+
+    # HTML リダイレクト（200）で github_error を返し、トークン交換には進まない
+    assert response.status_code == 200
+    assert mock_async_client.call_count == 0
+    assert "github_error=" in response.text
+    # 認証 Cookie は発行されない
+    assert "access_token=" not in response.headers.get("set-cookie", "")
+
+
+def test_github_callback_post_rejects_missing_state_cookie(client) -> None:
+    """POST /auth/github/callback は state Cookie が無いと 401 で拒否する。
+
+    API を直叩きして Cookie を持たない攻撃者のリクエストはトークン交換に進めない。
+    """
+    client.cookies.clear()  # 認可開始を経ていない（state Cookie 無し）
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+        response = client.post(
+            "/auth/github/callback",
+            json={"code": "test-code", "state": "any-state-from-frontend"},
+            headers={
+                "Host": "devforge-dev-XXXXX-an.a.run.app",
+                "X-Forwarded-Proto": "https",
+            },
+        )
+
+    assert response.status_code == 401
+    # state 照合より先に外部 API を叩いていないこと
+    assert mock_async_client.call_count == 0
+
+
+def test_github_callback_post_rejects_mismatched_state(client) -> None:
+    """POST /auth/github/callback は Cookie と body の state 不一致を 401 で拒否する。
+
+    攻撃者が任意の code/state を投げても、サーバー保持の state と一致しなければ通らない。
+    """
+    _seed_oauth_state(client, "real-state")
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+        response = client.post(
+            "/auth/github/callback",
+            json={"code": "test-code", "state": "attacker-state"},
+            headers={
+                "Host": "devforge-dev-XXXXX-an.a.run.app",
+                "X-Forwarded-Proto": "https",
+            },
+        )
+
+    assert response.status_code == 401
+    assert mock_async_client.call_count == 0
+
+
+def test_github_callback_post_succeeds_with_matching_state(client) -> None:
+    """POST /auth/github/callback は Cookie と body の state 一致でトークン交換に進む。
+
+    照合成功後は使い捨ての state Cookie を破棄する（リプレイ防止）。
     """
     token_response = MagicMock()
     token_response.json.return_value = {"access_token": "github-access-token"}
     user_response = MagicMock()
     user_response.json.return_value = {"id": 67890, "login": "octo-post"}
 
-    client.cookies.clear()  # Cookie が無くても通ることを確認する
+    _seed_oauth_state(client, "matching-state")
 
     with patch("httpx.AsyncClient") as mock_cls:
         mock_http = AsyncMock()
@@ -287,7 +367,7 @@ def test_github_callback_post_does_not_require_cookie(client) -> None:
 
         response = client.post(
             "/auth/github/callback",
-            json={"code": "test-code", "state": "any-state-from-frontend"},
+            json={"code": "test-code", "state": "matching-state"},
             headers={
                 "Host": "devforge-dev-XXXXX-an.a.run.app",
                 "X-Forwarded-Proto": "https",
@@ -298,7 +378,10 @@ def test_github_callback_post_does_not_require_cookie(client) -> None:
     # username に "github:" プレフィックスを付けない（素の login 名で保存する）
     assert response.json()["username"] == "octo-post"
     assert response.json()["is_github_user"] is True
-    assert "access_token=" in response.headers["set-cookie"]
+    all_set_cookie = response.headers["set-cookie"]
+    assert "access_token=" in all_set_cookie
+    # 照合済みの state Cookie が Max-Age=0 で破棄されること
+    assert f"{GITHUB_OAUTH_STATE_COOKIE}=" in all_set_cookie
     # GitHub への redirect_uri も /github/callback でトークン交換していることを確認する
     posted_kwargs = mock_http.post.call_args.kwargs
     assert posted_kwargs["json"]["redirect_uri"].endswith("/github/callback")
@@ -311,6 +394,8 @@ def test_github_callback_post_uses_frontend_origin_when_callback_base_url_unset(
     token_response.json.return_value = {"access_token": "github-access-token"}
     user_response = MagicMock()
     user_response.json.return_value = {"id": 24680, "login": "octo-local"}
+
+    _seed_oauth_state(client, "state-from-frontend")
 
     with patch("httpx.AsyncClient") as mock_cls:
         mock_http = AsyncMock()

--- a/backend/tests/auth/test_token_manager.py
+++ b/backend/tests/auth/test_token_manager.py
@@ -129,15 +129,23 @@ def test_github_callback_post_sets_session_cookie_with_httponly(client) -> None:
         )
 
     assert response.status_code == 200
-    all_set_cookie = response.headers.get("set-cookie", "")
-    # session Cookie が設定されていること
-    assert "session=" in all_set_cookie
+    # HttpOnly / SameSite は session Cookie 自身のエントリで検証する。
+    # マージ文字列だと oauth_state など他 Cookie の属性を誤って拾うため個別に判定する。
+    session_cookie = next(
+        (
+            value
+            for key, value in response.headers.multi_items()
+            if key.lower() == "set-cookie" and value.startswith("session=")
+        ),
+        "",
+    )
+    assert session_cookie, "session Cookie が Set-Cookie に存在すること"
     # HttpOnly 属性が付与されていること
-    assert "HttpOnly" in all_set_cookie
+    assert "HttpOnly" in session_cookie
     # SameSite 属性が付与されていること（ローカルでは lax）
-    assert "samesite=lax" in all_set_cookie.lower()
+    assert "samesite=lax" in session_cookie.lower()
     # Firebase 時代の __session Cookie 名が使われていないこと
-    assert "__session=" not in all_set_cookie
+    assert "__session=" not in response.headers.get("set-cookie", "")
 
 
 def test_logout_clears_session_cookie_with_max_age_zero(client) -> None:

--- a/backend/tests/auth/test_token_manager.py
+++ b/backend/tests/auth/test_token_manager.py
@@ -13,6 +13,7 @@ from app.core.security.auth import (
     create_refresh_token,
 )
 from app.core.settings import get_cookie_samesite, get_cookie_secure
+from app.routers.auth.token_manager import GITHUB_OAUTH_STATE_COOKIE
 from jose import jwt
 
 from conftest import _test_public_key, auth_header
@@ -109,6 +110,9 @@ def test_github_callback_post_sets_session_cookie_with_httponly(client) -> None:
     token_response.json.return_value = {"access_token": "github-access-token"}
     user_response = MagicMock()
     user_response.json.return_value = {"id": 11111, "login": "cookie-test-user"}
+
+    # CSRF 対策の state Cookie をセット（body の state と一致させる）
+    client.cookies.set(GITHUB_OAUTH_STATE_COOKIE, "state-from-frontend")
 
     with patch("httpx.AsyncClient") as mock_cls:
         mock_http = AsyncMock()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260507.1.tgz",
-      "integrity": "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260609.1.tgz",
+      "integrity": "sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==",
       "cpu": [
         "x64"
       ],
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260507.1.tgz",
-      "integrity": "sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260609.1.tgz",
+      "integrity": "sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==",
       "cpu": [
         "arm64"
       ],
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260507.1.tgz",
-      "integrity": "sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260609.1.tgz",
+      "integrity": "sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==",
       "cpu": [
         "x64"
       ],
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260507.1.tgz",
-      "integrity": "sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260609.1.tgz",
+      "integrity": "sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==",
       "cpu": [
         "arm64"
       ],
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260507.1.tgz",
-      "integrity": "sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260609.1.tgz",
+      "integrity": "sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2586,9 +2586,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.16.tgz",
+      "integrity": "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -3109,9 +3109,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5954,17 +5954,17 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260507.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260507.1.tgz",
-      "integrity": "sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw==",
+      "version": "4.20260609.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260609.0.tgz",
+      "integrity": "sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
+        "sharp": "0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260507.1",
-        "ws": "8.18.0",
+        "workerd": "1.20260609.1",
+        "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -6067,9 +6067,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6489,9 +6489,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6509,7 +6509,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6645,9 +6645,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7226,9 +7226,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8230,9 +8230,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260507.1.tgz",
-      "integrity": "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==",
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260609.1.tgz",
+      "integrity": "sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8243,17 +8243,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260507.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260507.1",
-        "@cloudflare/workerd-linux-64": "1.20260507.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260507.1",
-        "@cloudflare/workerd-windows-64": "1.20260507.1"
+        "@cloudflare/workerd-darwin-64": "1.20260609.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260609.1",
+        "@cloudflare/workerd-linux-64": "1.20260609.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260609.1",
+        "@cloudflare/workerd-windows-64": "1.20260609.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.90.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.0.tgz",
-      "integrity": "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==",
+      "version": "4.99.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.99.0.tgz",
+      "integrity": "sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -8261,10 +8261,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260507.1",
+        "miniflare": "4.20260609.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260507.1"
+        "workerd": "1.20260609.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -8274,10 +8274,10 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260507.1"
+        "@cloudflare/workers-types": "^4.20260609.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -8792,9 +8792,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -525,6 +525,9 @@ export interface paths {
          *
          *     一部の CDN / リバースプロキシは 303 レスポンスの Set-Cookie を除去することがあるため、
          *     200 + HTML リダイレクトで Cookie を確実にセットする。
+         *
+         *     state は認可開始時に発行した HttpOnly Cookie とサーバー側で照合する（CSRF 対策）。
+         *     照合失敗時はトークン交換に進まず、エラー付きでフロントへリダイレクトする。
          */
         get: operations["github_callback_redirect_auth_github_callback_get"];
         put?: never;
@@ -532,7 +535,8 @@ export interface paths {
          * Github Callback
          * @description GitHub OAuth コードを受け取り、認証 Cookie を発行する。
          *
-         *     state はフロントの sessionStorage で検証済みのためサーバー側では再検証しない。
+         *     state は認可開始時に発行した HttpOnly Cookie とサーバー側で照合する（CSRF 対策）。
+         *     フロントの sessionStorage 照合に依存せず API 直叩きのログイン CSRF を防ぐ。
          *     redirect_uri は GitHub OAuth App の登録値 (`/github/callback`) と一致させる必要がある。
          */
         post: operations["github_callback_auth_github_callback_post"];
@@ -573,7 +577,8 @@ export interface paths {
          * Github Login Url
          * @description GitHub OAuth 認可 URL と state を返す。
          *
-         *     state はフロントが sessionStorage に保持し、コールバック時に CSRF 検証する。
+         *     state は HttpOnly Cookie に保存し、コールバックでサーバー側照合する（CSRF 対策の正本）。
+         *     レスポンスの state はフロントの sessionStorage 照合（多層防御）にも併用する。
          */
         get: operations["github_login_url_auth_github_login_url_get"];
         put?: never;
@@ -1116,7 +1121,8 @@ export interface components {
          * GitHubLoginUrlResponse
          * @description GitHub OAuth 認可 URL と CSRF 検証用 state を返すレスポンス。
          *
-         *     state はフロントが sessionStorage に保持し、コールバック時に CSRF 検証する。
+         *     state はサーバー側で HttpOnly Cookie に保存され、コールバックで照合される（正本）。
+         *     レスポンスの state はフロントの sessionStorage 照合（多層防御）にも併用する。
          */
         GitHubLoginUrlResponse: {
             /** Authorization Url */
@@ -2423,6 +2429,7 @@ export interface operations {
         parameters: {
             query?: {
                 code?: string | null;
+                state?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## 背景

`SEC_review`（`report/SEC_report_20260610_1445.md`）で検出した High 1 件への対応。

GitHub OAuth の `state` 検証が **frontend の sessionStorage のみ**で行われ、backend では照合されていなかった。`validate_github_oauth_state` は実装・単体テスト済みだが **どの router からも呼ばれておらず**、`POST /auth/github/callback` は任意の `code`/`state` をそのまま受理していた。

これは `.claude/rules/backend/auth-security.md`「GitHub OAuth の state は **backend 側 Cookie で検証**する。frontend だけで検証しないこと」への直接違反。

### 攻撃シナリオ
state は JS から読める sessionStorage にあり backend は照合しないため、攻撃者は frontend の検証を迂回して `POST /auth/github/callback` に自分の OAuth `code` を直接投げ込める（ログイン CSRF / code 注入）。sessionStorage の照合は API 直叩きで完全にバイパスされる。

## 変更内容

- **認可開始**（`/auth/github/login-url` / `/auth/github/login`）で `state` を **HttpOnly Cookie** に発行
- **POST/GET callback** で Cookie 値と provided state を `validate_github_oauth_state` で照合し、照合後に使い捨て破棄（リプレイ防止）
- 既存の `set_cookie`（HttpOnly + Secure + SameSite）を再利用。本番では既存 session Cookie と同一属性で round-trip する
- **テスト**: 非検証を正常仕様として固定化していた `test_github_callback_post_does_not_require_cookie` を安全側へ反転し、state 欠落/不一致を **401**（GET はエラーリダイレクト）で固定する exploit テストを追加
- **依存**: `npm audit fix` で moderate 6 件（qs / ws / miniflare / wrangler / postcss）を解消（`package-lock.json` の transitive のみ・`package.json` 無変更）

### フロント無変更で互換
`GitHubCallbackRequest` は既に `state` を含み、frontend は `{code, state}` を `credentials:"include"` で送信、login-url も `credentials:"include"` で取得済み。state Cookie は session Cookie と同一経路で自動 round-trip するため **frontend のコード変更は不要**。

## 検証

- `make ci`: ✅（lint + test + build-frontend 全 pass）
- backend: **431 passed** / frontend: **299 passed**
- 追加 exploit テスト4件。**修正前赤・修正後緑を実機確認**（POST 検証を一時無効化 → reject 2 件 fail → 復元後 pass）
- `npm audit --audit-level=high`: **0 vulnerabilities**
- E2E: 未実行（frontend 無変更 + API 契約不変。E2E は backend 応答を全モックするため本変更を観測不可）

## 破壊的変更 / 注意

- OAuth callback が **state Cookie を必須化**（挙動変更だが contract 不変・フロント互換）
- 追加 env は不要（Cookie 属性は既存 `COOKIE_SECURE` / `COOKIE_SAMESITE` で制御）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GitHub OAuth authentication security by implementing server-side state validation during the callback process. OAuth state parameters are now securely managed through HttpOnly cookies with server-side verification, strengthening the overall authentication mechanism and improving protection during the OAuth callback phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->