### PR TITLE
feat(resume): 職務経歴書に連絡先（email / github）を追加し PDF/Markdown でリンク表示

### DIFF
--- a/backend/alembic_migrations/versions/0043_add_contact_to_resumes.py
+++ b/backend/alembic_migrations/versions/0043_add_contact_to_resumes.py
@@ -1,0 +1,41 @@
+"""職務経歴書（resumes）に連絡先カラム（email / github_url）を追加する
+
+- resumes に email（メールアドレス・必須運用）と github_url（GitHub URL・任意）を追加。
+  既存行は連絡先未入力のため server_default="" で後方互換を保つ（次回フォーム保存時に
+  必須バリデーションが効く）。
+
+libSQL (SQLite 互換) は ADD COLUMN を直接サポートするため upgrade は op.add_column を使う。
+downgrade の列削除は、resumes が子テーブル（resume_experiences / resume_qualifications）から
+FK 参照される親テーブルのため batch_alter_table（テーブル再作成）を使わない。素のカラムは
+SQLite/libSQL 3.35+ の ALTER TABLE DROP COLUMN で直接削除できる。
+
+Revision ID: 0043_add_contact_to_resumes
+Revises: 0042_drop_users_hashed_password
+Create Date: 2026-06-10 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0043_add_contact_to_resumes"
+down_revision: Union[str, None] = "0042_drop_users_hashed_password"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resumes",
+        sa.Column("email", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "resumes",
+        sa.Column("github_url", sa.String(length=255), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("resumes", "github_url")
+    op.drop_column("resumes", "email")

--- a/backend/app/messages.json
+++ b/backend/app/messages.json
@@ -48,7 +48,9 @@
       "invalid_input": "入力内容を確認してください。",
       "date_range_invalid": "開始日は終了日より前に設定してください。",
       "start_date_required": "開始年月を入力してください。",
-      "end_date_required": "在職中でない場合は終了年月を入力してください。"
+      "end_date_required": "在職中でない場合は終了年月を入力してください。",
+      "email_invalid": "メールアドレスの形式が正しくありません。",
+      "github_url_invalid": "GitHub の URL は https://github.com/ で始まる形式で入力してください。"
     },
     "server": {
       "internal_error": "サーバーエラーが発生しました。しばらくしてから再度お試しください。",

--- a/backend/app/models/resume.py
+++ b/backend/app/models/resume.py
@@ -28,6 +28,9 @@ class Resume(Base):
         String(36), ForeignKey("users.id"), nullable=False, index=True
     )
     full_name: Mapped[str] = mapped_column(String(120), nullable=False, default="")
+    # 連絡先（メールは必須・GitHub URL は任意）。バリデーションは schemas/resume.py の ResumeBase が正本。
+    email: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    github_url: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     career_summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
     self_pr: Mapped[str] = mapped_column(Text, nullable=False)
     experience_rows: Mapped[list["ResumeExperience"]] = relationship(

--- a/backend/app/repositories/resume.py
+++ b/backend/app/repositories/resume.py
@@ -41,6 +41,8 @@ class ResumeRepository(SingleUserDocumentRepository):
 
     def _apply_payload(self, entity: Resume, payload: dict[str, object]) -> None:
         entity.full_name = payload["full_name"]
+        entity.email = payload["email"]
+        entity.github_url = payload.get("github_url", "")
         entity.career_summary = payload["career_summary"]
         entity.self_pr = payload["self_pr"]
         sorted_experiences = sort_by_period_desc(

--- a/backend/app/routers/resumes.py
+++ b/backend/app/routers/resumes.py
@@ -31,6 +31,8 @@ def _resume_to_payload(resume: Resume) -> dict:
     """Resume ORM から PDF/Markdown 生成用 payload を組み立てる。"""
     return {
         "full_name": resume.full_name,
+        "email": resume.email,
+        "github_url": resume.github_url,
         "career_summary": resume.career_summary,
         "self_pr": resume.self_pr,
         "experiences": resume.experiences,

--- a/backend/app/schemas/resume.py
+++ b/backend/app/schemas/resume.py
@@ -245,19 +245,20 @@ class ResumeBase(BaseModel):
     @field_validator("email")
     @classmethod
     def validate_email(cls, value: str) -> str:
-        """メールアドレスの簡易形式チェック。不正なら 422（日本語メッセージ）で返す。"""
-        if not _EMAIL_PATTERN.match(value.strip()):
+        """メールアドレスの簡易形式チェック。前後空白を除去して正規化し、不正なら 422（日本語）で返す。"""
+        trimmed = value.strip()
+        if not _EMAIL_PATTERN.match(trimmed):
             raise ValueError(get_error("validation.email_invalid"))
-        return value
+        return trimmed
 
     @field_validator("github_url")
     @classmethod
     def validate_github_url(cls, value: str) -> str:
-        """GitHub URL は任意。値があるときだけ ``https://github.com/`` 始まりを要求する。"""
+        """GitHub URL は任意。値があるときだけ ``https://github.com/`` 始まりを要求する。前後空白は除去する。"""
         stripped = value.strip()
         if stripped and not stripped.startswith(_GITHUB_URL_PREFIX):
             raise ValueError(get_error("validation.github_url_invalid"))
-        return value
+        return stripped
 
 
 class ResumeCreate(ResumeBase):

--- a/backend/app/schemas/resume.py
+++ b/backend/app/schemas/resume.py
@@ -12,11 +12,19 @@ FE 同期: 本モジュールの各 Item / レスポンス型は ``frontend/src/
 ``Client.vacation_*``（期間・詳細）を使う。
 """
 
+import re
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from ..core.date_utils import to_jst
 from ..core.messages import get_error
@@ -219,12 +227,37 @@ class Experience(BaseModel):
         return self
 
 
+# 簡易メール形式（RFC 5322 完全準拠ではなく UX 優先の最小チェック）。FE 側 payloadBuilders と一致させる。
+_EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+# GitHub アカウント URL の接頭辞。値があるときのみ前方一致で検証する。
+_GITHUB_URL_PREFIX = "https://github.com/"
+
+
 class ResumeBase(BaseModel):
     full_name: str = Field(min_length=1, max_length=120)
+    email: str = Field(min_length=1, max_length=255)
+    github_url: str = Field(default="", max_length=255)
     career_summary: str = Field(min_length=1, max_length=2000)
     self_pr: str = Field(min_length=1, max_length=2000)
     experiences: list[Experience] = Field(default_factory=list)
     qualifications: list[ResumeQualificationItem] = Field(default_factory=list)
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        """メールアドレスの簡易形式チェック。不正なら 422（日本語メッセージ）で返す。"""
+        if not _EMAIL_PATTERN.match(value.strip()):
+            raise ValueError(get_error("validation.email_invalid"))
+        return value
+
+    @field_validator("github_url")
+    @classmethod
+    def validate_github_url(cls, value: str) -> str:
+        """GitHub URL は任意。値があるときだけ ``https://github.com/`` 始まりを要求する。"""
+        stripped = value.strip()
+        if stripped and not stripped.startswith(_GITHUB_URL_PREFIX):
+            raise ValueError(get_error("validation.github_url_invalid"))
+        return value
 
 
 class ResumeCreate(ResumeBase):

--- a/backend/app/services/markdown/generators/resume_generator.py
+++ b/backend/app/services/markdown/generators/resume_generator.py
@@ -19,6 +19,15 @@ def build_resume_markdown(payload: dict[str, Any]) -> str:
     full_name = payload.get("full_name", "")
     if full_name:
         lines.append(field_line("氏名", full_name))
+    # 連絡先（メールは必須・GitHub URL は任意。値があるときだけ行を出す）
+    email = payload.get("email", "")
+    if email:
+        lines.append(field_line("email", email))
+    github_url = payload.get("github_url", "")
+    if github_url:
+        # github URL は Markdown リンク記法でハイパーリンク化する（GitHub/各種ビューアで
+        # 青・下線のリンク表示になる）。href は schema で https://github.com/ 始まりに検証済み。
+        lines.append(field_line("github", f"[{github_url}]({github_url})"))
     lines.append("")
 
     qualifications = payload.get("qualifications", [])

--- a/backend/app/services/pdf/generators/resume_generator.py
+++ b/backend/app/services/pdf/generators/resume_generator.py
@@ -220,6 +220,24 @@ def _build_html(resume: dict) -> str:
         f'<div class="meta">氏名　<span data-fp="full_name">{_esc(full_name)}</span></div>',
     )
 
+    # 連絡先（メールは必須・GitHub URL は任意。値があるときだけ行を出す）
+    email = resume.get("email") or ""
+    if email:
+        parts.append(
+            f'<div class="meta">email　<span data-fp="email">{_esc(email)}</span></div>',
+        )
+    github_url = resume.get("github_url") or ""
+    if github_url:
+        # github URL はハイパーリンク表示（青・下線）にする。href は schema で
+        # https://github.com/ 始まりに検証済みのため安全。data-fp は左右 diff の
+        # ハイライト対象として span ではなく <a> に直接付与する（annotateHtml は
+        # [data-fp] 全要素を対象にするため要素種別は問わない）。
+        esc_url = _esc(github_url)
+        parts.append(
+            f'<div class="meta">github　'
+            f'<a class="meta-link" href="{esc_url}" data-fp="github_url">{esc_url}</a></div>',
+        )
+
     # 記載日（日本時間）
     today = datetime.now(JST)
     parts.append(

--- a/backend/app/services/pdf/templates/resume.css
+++ b/backend/app/services/pdf/templates/resume.css
@@ -35,6 +35,12 @@ h1 {
   margin-bottom: 4mm;
 }
 
+/* 連絡先の github URL をハイパーリンク表示（青・下線）にする。 */
+.meta-link {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
 h2 {
   font-size: 12pt;
   border-bottom: 2px solid #333;

--- a/backend/tests/auth/test_endpoints.py
+++ b/backend/tests/auth/test_endpoints.py
@@ -129,6 +129,7 @@ def test_me_returns_current_user(client) -> None:
 def _csrf_resume_payload() -> dict:
     return {
         "full_name": "テスト",
+        "email": "test@example.com",
         "career_summary": "要約",
         "self_pr": "自己PR",
         "experiences": [],

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -166,6 +166,7 @@ def make_resume_payload(**overrides) -> dict:
     """
     payload: dict = {
         "full_name": "山田 太郎",
+        "email": "yamada@example.com",
         "career_summary": "キャリアサマリー",
         "self_pr": "自己PR",
         "experiences": [

--- a/backend/tests/security/_helpers.py
+++ b/backend/tests/security/_helpers.py
@@ -22,6 +22,7 @@ DUMMY_UUID = "00000000-0000-0000-0000-000000000001"
 
 RESUME_PAYLOAD: dict = {
     "full_name": "山田 太郎",
+    "email": "yamada@example.com",
     "career_summary": "キャリアサマリー",
     "self_pr": "自己PR",
     "experiences": [],

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -30,6 +30,7 @@ def test_resume_crud(client: TestClient) -> None:
         "/api/resumes",
         json={
             "full_name": "田中太郎",
+            "email": "tanaka@example.com",
             "career_summary": "キャリアサマリー",
             "self_pr": "自己PR",
             "experiences": [],
@@ -50,6 +51,7 @@ def test_resume_crud(client: TestClient) -> None:
         f"/api/resumes/{resume_id}",
         json={
             "full_name": "田中花子",
+            "email": "tanaka@example.com",
             "career_summary": "更新済みサマリー",
             "self_pr": "自己PR",
             "experiences": [],
@@ -62,6 +64,68 @@ def test_resume_crud(client: TestClient) -> None:
     assert resp.json()["full_name"] == "田中花子"
 
 
+def test_resume_contact_round_trips(client: TestClient) -> None:
+    """メール・GitHub URL が作成→取得で往復することを確認する。"""
+    headers = auth_header(client, "resume-contact-user")
+    resp = client.post(
+        "/api/resumes",
+        json={
+            "full_name": "連絡先 太郎",
+            "email": "contact@example.com",
+            "github_url": "https://github.com/contact-taro",
+            "career_summary": "要約",
+            "self_pr": "自己PR",
+            "experiences": [],
+            "qualifications": [],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    resp = client.get("/api/resumes/latest", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["email"] == "contact@example.com"
+    assert body["github_url"] == "https://github.com/contact-taro"
+
+
+def test_resume_rejects_invalid_email_via_api(client: TestClient) -> None:
+    """不正なメール形式は 422 で拒否される。"""
+    headers = auth_header(client, "resume-bademail-user")
+    resp = client.post(
+        "/api/resumes",
+        json={
+            "full_name": "太郎",
+            "email": "not-an-email",
+            "career_summary": "要約",
+            "self_pr": "自己PR",
+            "experiences": [],
+            "qualifications": [],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_resume_rejects_invalid_github_url_via_api(client: TestClient) -> None:
+    """github.com 以外の GitHub URL は 422 で拒否される。"""
+    headers = auth_header(client, "resume-badgithub-user")
+    resp = client.post(
+        "/api/resumes",
+        json={
+            "full_name": "太郎",
+            "email": "ok@example.com",
+            "github_url": "https://gitlab.com/taro",
+            "career_summary": "要約",
+            "self_pr": "自己PR",
+            "experiences": [],
+            "qualifications": [],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
 def test_resume_qualifications_sorted_asc(client: TestClient) -> None:
     """資格一覧が取得日昇順で返ることを確認する。"""
     headers = auth_header(client, "resume-sort-user")
@@ -70,6 +134,7 @@ def test_resume_qualifications_sorted_asc(client: TestClient) -> None:
         "/api/resumes",
         json={
             "full_name": "ソート確認",
+            "email": "sort@example.com",
             "career_summary": "要約",
             "self_pr": "自己PR",
             "experiences": [],
@@ -97,6 +162,7 @@ def test_resume_qualification_date_is_year_month(client: TestClient) -> None:
         "/api/resumes",
         json={
             "full_name": "年月確認",
+            "email": "ym@example.com",
             "career_summary": "要約",
             "self_pr": "自己PR",
             "experiences": [],
@@ -119,6 +185,7 @@ def test_resume_round_trips_nested_structure(client: TestClient) -> None:
 
     payload = {
         "full_name": "山田 太郎",
+        "email": "yamada@example.com",
         "career_summary": "キャリアサマリー",
         "self_pr": "自己PR",
         "experiences": [
@@ -179,6 +246,7 @@ def test_resume_round_trips_non_it_and_vacation(client: TestClient) -> None:
 
     payload = {
         "full_name": "佐藤 花子",
+        "email": "sato@example.com",
         "career_summary": "キャリアサマリー",
         "self_pr": "自己PR",
         "experiences": [
@@ -284,6 +352,7 @@ def test_resume_get_by_id(client: TestClient) -> None:
         "/api/resumes",
         json={
             "full_name": "山田 太郎",
+            "email": "yamada@example.com",
             "career_summary": "サマリー",
             "self_pr": "自己PR",
             "experiences": [],
@@ -318,6 +387,7 @@ def test_resume_preview_returns_annotated_html(client: TestClient) -> None:
         "/api/resumes/preview",
         json={
             "full_name": "山田太郎",
+            "email": "yamada@example.com",
             "career_summary": "キャリアサマリー",
             "self_pr": "自己PR",
             "experiences": [
@@ -374,6 +444,7 @@ def test_resume_preview_validation_error(client: TestClient) -> None:
         "/api/resumes/preview",
         json={
             "full_name": "",
+            "email": "yamada@example.com",
             "career_summary": "x",
             "self_pr": "y",
             "experiences": [],

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from conftest import auth_header
+from conftest import auth_header, make_resume_payload
 
 # ── CRUD: Auth required (401 without token) ────────────────────
 
@@ -67,19 +67,12 @@ def test_resume_crud(client: TestClient) -> None:
 def test_resume_contact_round_trips(client: TestClient) -> None:
     """メール・GitHub URL が作成→取得で往復することを確認する。"""
     headers = auth_header(client, "resume-contact-user")
-    resp = client.post(
-        "/api/resumes",
-        json={
-            "full_name": "連絡先 太郎",
-            "email": "contact@example.com",
-            "github_url": "https://github.com/contact-taro",
-            "career_summary": "要約",
-            "self_pr": "自己PR",
-            "experiences": [],
-            "qualifications": [],
-        },
-        headers=headers,
+    payload = make_resume_payload(
+        full_name="連絡先 太郎",
+        email="contact@example.com",
+        github_url="https://github.com/contact-taro",
     )
+    resp = client.post("/api/resumes", json=payload, headers=headers)
     assert resp.status_code == 201, resp.text
 
     resp = client.get("/api/resumes/latest", headers=headers)
@@ -92,37 +85,16 @@ def test_resume_contact_round_trips(client: TestClient) -> None:
 def test_resume_rejects_invalid_email_via_api(client: TestClient) -> None:
     """不正なメール形式は 422 で拒否される。"""
     headers = auth_header(client, "resume-bademail-user")
-    resp = client.post(
-        "/api/resumes",
-        json={
-            "full_name": "太郎",
-            "email": "not-an-email",
-            "career_summary": "要約",
-            "self_pr": "自己PR",
-            "experiences": [],
-            "qualifications": [],
-        },
-        headers=headers,
-    )
+    payload = make_resume_payload(email="not-an-email")
+    resp = client.post("/api/resumes", json=payload, headers=headers)
     assert resp.status_code == 422
 
 
 def test_resume_rejects_invalid_github_url_via_api(client: TestClient) -> None:
     """github.com 以外の GitHub URL は 422 で拒否される。"""
     headers = auth_header(client, "resume-badgithub-user")
-    resp = client.post(
-        "/api/resumes",
-        json={
-            "full_name": "太郎",
-            "email": "ok@example.com",
-            "github_url": "https://gitlab.com/taro",
-            "career_summary": "要約",
-            "self_pr": "自己PR",
-            "experiences": [],
-            "qualifications": [],
-        },
-        headers=headers,
-    )
+    payload = make_resume_payload(github_url="https://gitlab.com/taro")
+    resp = client.post("/api/resumes", json=payload, headers=headers)
     assert resp.status_code == 422
 
 

--- a/backend/tests/test_markdown_generator.py
+++ b/backend/tests/test_markdown_generator.py
@@ -34,6 +34,42 @@ def test_capital_unit_defaults_to_sen_man_when_missing() -> None:
     assert "5千万円" in md
 
 
+def test_contact_fields_rendered_when_present() -> None:
+    md = build_resume_markdown(
+        {
+            "full_name": "山田 太郎",
+            "email": "yamada@example.com",
+            "github_url": "https://github.com/yamada",
+            "career_summary": "職務要約",
+            "self_pr": "自己PR",
+            "qualifications": [],
+            "experiences": [],
+        }
+    )
+    assert "yamada@example.com" in md
+    # ラベルは email / github（小文字）。
+    assert "**email:**" in md
+    assert "**github:**" in md
+    # github URL は Markdown リンク記法でハイパーリンク化する。
+    assert "[https://github.com/yamada](https://github.com/yamada)" in md
+
+
+def test_contact_fields_omitted_when_empty() -> None:
+    # github URL は任意。空なら github 行を出さない（email は必須運用だが空入力にも耐える）。
+    md = build_resume_markdown(
+        {
+            "full_name": "山田 太郎",
+            "email": "yamada@example.com",
+            "github_url": "",
+            "career_summary": "職務要約",
+            "self_pr": "自己PR",
+            "qualifications": [],
+            "experiences": [],
+        }
+    )
+    assert "github" not in md
+
+
 def _it_experience() -> dict:
     return {
         "company": "Example株式会社",

--- a/backend/tests/test_markdown_generator.py
+++ b/backend/tests/test_markdown_generator.py
@@ -67,7 +67,7 @@ def test_contact_fields_omitted_when_empty() -> None:
             "experiences": [],
         }
     )
-    assert "github" not in md
+    assert "**github:**" not in md
 
 
 def _it_experience() -> dict:

--- a/backend/tests/test_pdf_generator.py
+++ b/backend/tests/test_pdf_generator.py
@@ -135,6 +135,44 @@ def test_build_html_annotates_data_fp() -> None:
     assert 'data-unit="qualifications.0"' in html
 
 
+def test_build_html_renders_contact_fields() -> None:
+    """メール・GitHub URL は値があるとき data-fp 付きで出力され、空なら省略される。"""
+    html = _build_html(
+        {
+            "full_name": "山田太郎",
+            "email": "yamada@example.com",
+            "github_url": "https://github.com/yamada",
+            "career_summary": "要約",
+            "self_pr": "PR",
+            "qualifications": [],
+            "experiences": [],
+        }
+    )
+    assert 'data-fp="email"' in html
+    assert "yamada@example.com" in html
+    # ラベルは email / github（小文字）で出す。
+    assert "email　" in html
+    assert "github　" in html
+    assert 'data-fp="github_url"' in html
+    assert "https://github.com/yamada" in html
+    # github URL はハイパーリンク（青・下線）として <a class="meta-link" href=...> で出す。
+    assert '<a class="meta-link" href="https://github.com/yamada"' in html
+
+    # GitHub URL は任意。空なら github_url ノードを出さない。
+    html_no_github = _build_html(
+        {
+            "full_name": "山田太郎",
+            "email": "yamada@example.com",
+            "github_url": "",
+            "career_summary": "要約",
+            "self_pr": "PR",
+            "qualifications": [],
+            "experiences": [],
+        }
+    )
+    assert 'data-fp="github_url"' not in html_no_github
+
+
 def test_build_html_period_binds_is_current() -> None:
     """在職中の期間は「現在」を is_current に、休暇期間は各日付フィールドに紐づける。"""
     payload = {

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -87,6 +87,7 @@ def test_unknown_category_is_rejected() -> None:
 def test_resume_requires_career_summary() -> None:
     payload = {
         "full_name": "山田 太郎",
+        "email": "yamada@example.com",
         "self_pr": "自己PR",
         "experiences": [experience_payload()],
         "qualifications": [],
@@ -98,6 +99,7 @@ def test_resume_requires_career_summary() -> None:
 
 def test_resume_requires_full_name() -> None:
     payload = {
+        "email": "yamada@example.com",
         "career_summary": "要約",
         "self_pr": "自己PR",
         "experiences": [experience_payload()],
@@ -106,6 +108,57 @@ def test_resume_requires_full_name() -> None:
 
     with pytest.raises(ValidationError):
         ResumeCreate(**payload)
+
+
+def _resume_payload(**overrides) -> dict:
+    """メール・GitHub URL 検証用の最小 ResumeCreate payload。"""
+    payload = {
+        "full_name": "山田 太郎",
+        "email": "yamada@example.com",
+        "career_summary": "要約",
+        "self_pr": "自己PR",
+        "experiences": [],
+        "qualifications": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_resume_requires_email() -> None:
+    """email は必須。欠落で ValidationError。"""
+    payload = _resume_payload()
+    del payload["email"]
+    with pytest.raises(ValidationError):
+        ResumeCreate(**payload)
+
+
+@pytest.mark.parametrize("bad_email", ["", "not-an-email", "foo@bar", "a@b.", "no domain.com"])
+def test_resume_rejects_invalid_email(bad_email: str) -> None:
+    """不正なメール形式は ValidationError。"""
+    with pytest.raises(ValidationError):
+        ResumeCreate(**_resume_payload(email=bad_email))
+
+
+def test_resume_accepts_valid_github_url() -> None:
+    """https://github.com/ 始まりの GitHub URL は受理される。"""
+    resume = ResumeCreate(**_resume_payload(github_url="https://github.com/yamada"))
+    assert resume.github_url == "https://github.com/yamada"
+
+
+def test_resume_allows_empty_github_url() -> None:
+    """GitHub URL は任意。空文字（デフォルト）でも受理される。"""
+    resume = ResumeCreate(**_resume_payload())
+    assert resume.github_url == ""
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    ["http://github.com/yamada", "https://gitlab.com/yamada", "github.com/yamada", "ftp://x"],
+)
+def test_resume_rejects_invalid_github_url(bad_url: str) -> None:
+    """github.com 以外・スキーム不正の URL は ValidationError。"""
+    with pytest.raises(ValidationError):
+        ResumeCreate(**_resume_payload(github_url=bad_url))
 
 
 def test_project_migrates_scale_to_team() -> None:

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -159,6 +159,8 @@ test.describe("未認証ユーザー（お試し入力）", () => {
           body: JSON.stringify({
             id: "new-resume-id",
             full_name: createdName ?? "",
+            email: "yamada@example.com",
+            github_url: "",
             career_summary: "",
             self_pr: "",
             experiences: [],
@@ -175,6 +177,8 @@ test.describe("未認証ユーザー（お試し入力）", () => {
         "career_draft",
         JSON.stringify({
           full_name: "山田太郎",
+          email: "yamada@example.com",
+          github_url: "",
           career_summary: "テスト要約",
           self_pr: "テスト自己PR",
           experiences: [

--- a/frontend/e2e/career-dirty-indicator.spec.ts
+++ b/frontend/e2e/career-dirty-indicator.spec.ts
@@ -16,6 +16,8 @@ async function setupResumeApi(page: Page) {
   const baseResume = {
     id: "resume-1",
     full_name: "山田 太郎",
+    email: "yamada@example.com",
+    github_url: "",
     career_summary: "サマリー",
     self_pr: "自己PR",
     experiences: [
@@ -94,6 +96,8 @@ test.describe("職務経歴書 未保存マーク", () => {
     const baseResumeWithProject = {
       id: "resume-1",
       full_name: "山田 太郎",
+      email: "yamada@example.com",
+      github_url: "",
       career_summary: "サマリー",
       self_pr: "自己PR",
       experiences: [

--- a/frontend/e2e/career-field-modal.spec.ts
+++ b/frontend/e2e/career-field-modal.spec.ts
@@ -28,6 +28,8 @@ async function setupResumeApi(page: Page) {
       body: JSON.stringify({
         id: "resume-1",
         full_name: "山田 太郎",
+        email: "yamada@example.com",
+        github_url: "",
         career_summary: "初期サマリー",
         self_pr: "初期自己PR",
         experiences: [],

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1321,10 +1321,17 @@ export interface components {
         ResumeCreate: {
             /** Career Summary */
             career_summary: string;
+            /** Email */
+            email: string;
             /** Experiences */
             experiences?: components["schemas"]["Experience-Input"][];
             /** Full Name */
             full_name: string;
+            /**
+             * Github Url
+             * @default
+             */
+            github_url: string;
             /** Qualifications */
             qualifications?: components["schemas"]["ResumeQualificationItem"][];
             /** Self Pr */
@@ -1357,10 +1364,17 @@ export interface components {
             career_summary: string;
             /** Created At */
             created_at: string;
+            /** Email */
+            email: string;
             /** Experiences */
             experiences?: components["schemas"]["Experience-Output"][];
             /** Full Name */
             full_name: string;
+            /**
+             * Github Url
+             * @default
+             */
+            github_url: string;
             /**
              * Id
              * Format: uuid
@@ -1377,10 +1391,17 @@ export interface components {
         ResumeUpdate: {
             /** Career Summary */
             career_summary: string;
+            /** Email */
+            email: string;
             /** Experiences */
             experiences?: components["schemas"]["Experience-Input"][];
             /** Full Name */
             full_name: string;
+            /**
+             * Github Url
+             * @default
+             */
+            github_url: string;
             /** Qualifications */
             qualifications?: components["schemas"]["ResumeQualificationItem"][];
             /** Self Pr */

--- a/frontend/src/components/forms/CareerDiffModal.module.css
+++ b/frontend/src/components/forms/CareerDiffModal.module.css
@@ -41,6 +41,14 @@
   min-height: 0;
   display: grid;
   grid-template-columns: 1fr 1fr 320px;
+  /*
+   * 行を明示的に minmax(0, 1fr) で固定する。未指定だと暗黙の auto 行になり、
+   * 変更点が多いときにサイドバーの中身（.list）の高さに合わせて行が伸び、
+   * モーダル（92vh / overflow:hidden）からはみ出した分が clip されてロール
+   * バックボタンや操作ボタンが見えなくなる。0 を下限にすることで中身では
+   * 伸びず、.list の overflow-y:auto が効いて全項目をスクロールで辿れる。
+   */
+  grid-template-rows: minmax(0, 1fr);
   gap: 0.75rem;
   padding: 0.5rem 1rem 0.75rem;
 }

--- a/frontend/src/components/forms/CareerResumeForm.tsx
+++ b/frontend/src/components/forms/CareerResumeForm.tsx
@@ -413,14 +413,18 @@ export function CareerResumeForm({ isAuthenticated }: { isAuthenticated: boolean
               <div className={`${shared.form} import-assign-form ${layout.formCol}`}>
                 {validationError && <p className={shared.error}>{validationError}</p>}
 
-                {/* 基本情報: 氏名・職務要約 */}
+                {/* 基本情報: 氏名・連絡先・職務要約 */}
                 <CareerBasicInfoSection
                   fullName={form.full_name}
+                  email={form.email}
+                  githubUrl={form.github_url}
                   careerSummary={form.career_summary}
                   loading={loading}
                   onChange={onChangeField}
                   onEditCareerSummary={() => setEditingField("career_summary")}
                   fullNameDirty={dirty.full_name}
+                  emailDirty={dirty.email}
+                  githubUrlDirty={dirty.github_url}
                   careerSummaryDirty={dirty.career_summary}
                   focusLocator={focusLocator}
                 />

--- a/frontend/src/components/forms/sections/CareerBasicInfoSection.tsx
+++ b/frontend/src/components/forms/sections/CareerBasicInfoSection.tsx
@@ -10,16 +10,24 @@ import { MarkdownFieldTrigger } from "../MarkdownFieldTrigger";
 type Props = {
   /** 氏名 */
   fullName: string;
+  /** メールアドレス（必須） */
+  email: string;
+  /** GitHub アカウント URL（任意） */
+  githubUrl: string;
   /** 職務要約（Markdown） */
   careerSummary: string;
   /** ローディング中（Skeleton 表示） */
   loading: boolean;
   /** フィールド変更ハンドラ */
-  onChange: (key: "full_name" | "career_summary", value: string) => void;
+  onChange: (key: "full_name" | "email" | "github_url" | "career_summary", value: string) => void;
   /** 職務要約の入力モーダルを開く */
   onEditCareerSummary: () => void;
   /** 氏名フィールドが未保存か */
   fullNameDirty?: boolean;
+  /** メールフィールドが未保存か */
+  emailDirty?: boolean;
+  /** GitHub URL フィールドが未保存か */
+  githubUrlDirty?: boolean;
   /** 職務要約フィールドが未保存か */
   careerSummaryDirty?: boolean;
   /** バリデーション失敗フィールドの位置情報（フォーカス・赤枠用） */
@@ -33,17 +41,25 @@ type Props = {
  */
 export function CareerBasicInfoSection({
   fullName,
+  email,
+  githubUrl,
   careerSummary,
   loading,
   onChange,
   onEditCareerSummary,
   fullNameDirty = false,
+  emailDirty = false,
+  githubUrlDirty = false,
   careerSummaryDirty = false,
   focusLocator = null,
 }: Props) {
   const fullNameInvalid = focusLocator?.kind === "full_name";
+  const emailInvalid = focusLocator?.kind === "email";
+  const githubUrlInvalid = focusLocator?.kind === "github_url";
   const careerSummaryInvalid = focusLocator?.kind === "career_summary";
   const fullNameRef = useFocusOnMatch<HTMLInputElement>(fullNameInvalid);
+  const emailRef = useFocusOnMatch<HTMLInputElement>(emailInvalid);
+  const githubUrlRef = useFocusOnMatch<HTMLInputElement>(githubUrlInvalid);
 
   return (
     <section className={shared.section}>
@@ -63,6 +79,43 @@ export function CareerBasicInfoSection({
             placeholder="例: 山田 太郎"
             required
             aria-invalid={fullNameInvalid || undefined}
+          />
+        )}
+      </label>
+      <label>
+        <span className={shared.labelText}>
+          メールアドレス<span className={shared.requiredBadge}>必須</span>
+          <DirtyDot visible={emailDirty} />
+        </span>
+        {loading ? (
+          <Skeleton height="38px" />
+        ) : (
+          <input
+            ref={emailRef}
+            type="email"
+            value={email}
+            onChange={(e) => onChange("email", e.target.value)}
+            placeholder="例: user@example.com"
+            required
+            aria-invalid={emailInvalid || undefined}
+          />
+        )}
+      </label>
+      <label>
+        <span className={shared.labelText}>
+          GitHub URL
+          <DirtyDot visible={githubUrlDirty} />
+        </span>
+        {loading ? (
+          <Skeleton height="38px" />
+        ) : (
+          <input
+            ref={githubUrlRef}
+            type="url"
+            value={githubUrl}
+            onChange={(e) => onChange("github_url", e.target.value)}
+            placeholder="例: https://github.com/yourname"
+            aria-invalid={githubUrlInvalid || undefined}
           />
         )}
       </label>

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -19,6 +19,9 @@
 /** フォーム入力時の事前バリデーションメッセージ（payloadBuilders などで使用） */
 export const VALIDATION_MESSAGES = {
   FULL_NAME_REQUIRED: "氏名を入力してください。",
+  EMAIL_REQUIRED: "メールアドレスを入力してください。",
+  EMAIL_INVALID: "メールアドレスの形式が正しくありません。",
+  GITHUB_URL_INVALID: "GitHub の URL は https://github.com/ で始まる形式で入力してください。",
   CAREER_SUMMARY_REQUIRED: "職務要約を入力してください。",
   SELF_PR_REQUIRED: "自己PRを入力してください。",
   EXPERIENCE_REQUIRED_FIELDS: "職務経歴は会社名、事業内容、開始年月を入力してください。",
@@ -246,6 +249,8 @@ export const LOADING_MESSAGES = {
 export const CAREER_DIFF_LABELS = {
   // トップレベル
   FULL_NAME: "氏名",
+  EMAIL: "メールアドレス",
+  GITHUB_URL: "GitHub URL",
   CAREER_SUMMARY: "職務要約",
   SELF_PR: "自己PR",
   // 配列のセグメント名（末尾に連番が付く: 「職歴1」）

--- a/frontend/src/formMappers.ts
+++ b/frontend/src/formMappers.ts
@@ -12,6 +12,8 @@ import type { ResumeResponse } from "./api/types";
 export function createInitialCareerForm(): CareerFormState {
   return {
     full_name: "",
+    email: "",
+    github_url: "",
     career_summary: "",
     self_pr: "",
     experiences: [{ ...blankCareerExperience }],
@@ -26,6 +28,8 @@ export function mapCareerResumeToForm(response: ResumeResponse): CareerFormState
   const qualifications = response.qualifications ?? [];
   return {
     full_name: response.full_name,
+    email: response.email,
+    github_url: response.github_url ?? "",
     career_summary: response.career_summary,
     self_pr: response.self_pr,
     experiences:

--- a/frontend/src/formTypes.ts
+++ b/frontend/src/formTypes.ts
@@ -1,4 +1,9 @@
-export type CareerTextFieldKey = "full_name" | "career_summary" | "self_pr";
+export type CareerTextFieldKey =
+  | "full_name"
+  | "email"
+  | "github_url"
+  | "career_summary"
+  | "self_pr";
 export type CareerExperienceFieldKey =
   | "company"
   | "business_description"

--- a/frontend/src/hooks/career/useCareerDirty.test.ts
+++ b/frontend/src/hooks/career/useCareerDirty.test.ts
@@ -15,6 +15,8 @@ import { useCareerDirty } from "./useCareerDirty";
 function buildForm(overrides: Partial<CareerFormState> = {}): CareerFormState {
   return {
     full_name: "山田 太郎",
+    email: "yamada@example.com",
+    github_url: "",
     career_summary: "サマリー",
     self_pr: "自己PR",
     experiences: [

--- a/frontend/src/hooks/career/useCareerDirty.ts
+++ b/frontend/src/hooks/career/useCareerDirty.ts
@@ -59,6 +59,8 @@ export type CareerDirtyMap = {
   /** 全体で何か未保存があるか（保存ボタン横用） */
   any: boolean;
   full_name: boolean;
+  email: boolean;
+  github_url: boolean;
   career_summary: boolean;
   self_pr: boolean;
   experiences: ExperienceDirty[];
@@ -106,6 +108,8 @@ function buildClean(form: CareerFormState): CareerDirtyMap {
   return {
     any: false,
     full_name: false,
+    email: false,
+    github_url: false,
     career_summary: false,
     self_pr: false,
     experiences: form.experiences.map((exp) => buildCleanExperience(exp)),
@@ -224,6 +228,8 @@ export function useCareerDirty(
     if (!baseline) return buildClean(form);
 
     const full_name = form.full_name !== baseline.full_name;
+    const email = form.email !== baseline.email;
+    const github_url = form.github_url !== baseline.github_url;
     const career_summary = form.career_summary !== baseline.career_summary;
     const self_pr = form.self_pr !== baseline.self_pr;
 
@@ -243,11 +249,19 @@ export function useCareerDirty(
       removedQualifications || qualifications.some((q) => q.self);
 
     const any =
-      full_name || career_summary || self_pr || experiencesAny || qualificationsAny;
+      full_name ||
+      email ||
+      github_url ||
+      career_summary ||
+      self_pr ||
+      experiencesAny ||
+      qualificationsAny;
 
     return {
       any,
       full_name,
+      email,
+      github_url,
       career_summary,
       self_pr,
       experiences,

--- a/frontend/src/hooks/career/useCareerExperienceMutators.test.ts
+++ b/frontend/src/hooks/career/useCareerExperienceMutators.test.ts
@@ -17,6 +17,8 @@ import { useCareerExperienceMutators } from "./useCareerExperienceMutators";
 function buildForm(overrides: Partial<CareerFormState> = {}): CareerFormState {
   return {
     full_name: "山田 太郎",
+    email: "yamada@example.com",
+    github_url: "",
     career_summary: "",
     self_pr: "",
     experiences: [

--- a/frontend/src/hooks/career/useResumeDiffPreview.test.ts
+++ b/frontend/src/hooks/career/useResumeDiffPreview.test.ts
@@ -15,6 +15,8 @@ const mockPreview = getCareerResumePreview as unknown as ReturnType<typeof vi.fn
 
 const validForm: CareerFormState = {
   full_name: "山田 太郎",
+  email: "yamada@example.com",
+  github_url: "",
   career_summary: "サマリー",
   self_pr: "自己PR",
   experiences: [],

--- a/frontend/src/payloadBuilders.test.ts
+++ b/frontend/src/payloadBuilders.test.ts
@@ -61,6 +61,8 @@ const blankExperience = (overrides: Partial<CareerExperienceForm> = {}): CareerE
 
 const baseState = (overrides: Partial<CareerFormState> = {}): CareerFormState => ({
   full_name: "山田 太郎",
+  email: "yamada@example.com",
+  github_url: "",
   career_summary: "要約",
   self_pr: "自己PR",
   experiences: [],
@@ -127,18 +129,46 @@ describe("buildCareerPayload (basic validation)", () => {
     expect(() => buildCareerPayload(baseState({ self_pr: "" }))).toThrow(/自己PR/);
   });
 
+  it("メールが空ならエラー", () => {
+    expect(() => buildCareerPayload(baseState({ email: "  " }))).toThrow(/メールアドレス/);
+  });
+
+  it("メール形式が不正ならエラー", () => {
+    expect(() => buildCareerPayload(baseState({ email: "not-an-email" }))).toThrow(/メールアドレス/);
+  });
+
+  it("GitHub URL が github.com 以外ならエラー", () => {
+    expect(() => buildCareerPayload(baseState({ github_url: "https://gitlab.com/x" }))).toThrow(
+      /GitHub/,
+    );
+  });
+
+  it("GitHub URL は任意（空なら通る）", () => {
+    const payload = buildCareerPayload(baseState({ github_url: "" }));
+    expect(payload.github_url).toBe("");
+  });
+
   it("必須項目が揃えば experiences/qualifications 空でも payload を返す", () => {
     const payload = buildCareerPayload(baseState());
     expect(payload.full_name).toBe("山田 太郎");
+    expect(payload.email).toBe("yamada@example.com");
     expect(payload.experiences).toEqual([]);
     expect(payload.qualifications).toEqual([]);
   });
 
   it("前後の空白は trim される", () => {
     const payload = buildCareerPayload(
-      baseState({ full_name: "  山田  ", career_summary: " 要約 ", self_pr: " PR " }),
+      baseState({
+        full_name: "  山田  ",
+        email: "  yamada@example.com  ",
+        github_url: "  https://github.com/yamada  ",
+        career_summary: " 要約 ",
+        self_pr: " PR ",
+      }),
     );
     expect(payload.full_name).toBe("山田");
+    expect(payload.email).toBe("yamada@example.com");
+    expect(payload.github_url).toBe("https://github.com/yamada");
     expect(payload.career_summary).toBe("要約");
     expect(payload.self_pr).toBe("PR");
   });

--- a/frontend/src/payloadBuilders.ts
+++ b/frontend/src/payloadBuilders.ts
@@ -12,6 +12,11 @@ import type {
   TechnologyStackItem,
 } from "./api/types";
 
+/** 簡易メール形式（UX 補助）。正本は backend schemas/resume.py の検証。 */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/** GitHub アカウント URL の接頭辞。値があるときだけ前方一致で検証する。 */
+const GITHUB_URL_PREFIX = "https://github.com/";
+
 export type TeamMemberForm = {
   role: string;
   count: string;
@@ -63,6 +68,8 @@ export type CareerExperienceForm = {
 
 export type CareerFormState = {
   full_name: string;
+  email: string;
+  github_url: string;
   career_summary: string;
   self_pr: string;
   experiences: CareerExperienceForm[];
@@ -77,6 +84,8 @@ export type CareerFormState = {
  */
 export type CareerFieldLocator =
   | { kind: "full_name" }
+  | { kind: "email" }
+  | { kind: "github_url" }
   | { kind: "career_summary" }
   | { kind: "self_pr" }
   | {
@@ -248,6 +257,18 @@ export function validateCareerForm(state: CareerFormState): CareerValidationErro
   if (!state.full_name.trim()) {
     return { message: VALIDATION_MESSAGES.FULL_NAME_REQUIRED, locator: { kind: "full_name" } };
   }
+  const email = state.email.trim();
+  if (!email) {
+    return { message: VALIDATION_MESSAGES.EMAIL_REQUIRED, locator: { kind: "email" } };
+  }
+  if (!EMAIL_PATTERN.test(email)) {
+    return { message: VALIDATION_MESSAGES.EMAIL_INVALID, locator: { kind: "email" } };
+  }
+  // GitHub URL は任意。入力があるときだけ形式を検証する。
+  const githubUrl = state.github_url.trim();
+  if (githubUrl && !githubUrl.startsWith(GITHUB_URL_PREFIX)) {
+    return { message: VALIDATION_MESSAGES.GITHUB_URL_INVALID, locator: { kind: "github_url" } };
+  }
   if (!state.career_summary.trim()) {
     return {
       message: VALIDATION_MESSAGES.CAREER_SUMMARY_REQUIRED,
@@ -417,6 +438,8 @@ export function buildCareerPayload(state: CareerFormState): ResumeCreate {
 
   return {
     full_name: state.full_name.trim(),
+    email: state.email.trim(),
+    github_url: state.github_url.trim(),
     career_summary: state.career_summary.trim(),
     self_pr: state.self_pr.trim(),
     experiences,

--- a/frontend/src/utils/careerDiff.test.ts
+++ b/frontend/src/utils/careerDiff.test.ts
@@ -66,6 +66,34 @@ describe("buildCareerChanges", () => {
     expect(changes[0].label).toBe("氏名");
   });
 
+  it("連絡先（email / github_url）の変更を検出し、ロールバックで復元できる", () => {
+    const baseline = buildForm();
+    const form = buildForm();
+    form.email = "sato@example.com";
+    form.github_url = "https://github.com/sato"; // baseline は ""（未設定）
+
+    const changes = buildCareerChanges(form, baseline);
+
+    // email: 既存値 → 新値の modified として検出される。
+    const emailChange = changes.find((c) => c.path.join(".") === "email");
+    expect(emailChange).toBeDefined();
+    expect(emailChange).toMatchObject({
+      kind: "modified",
+      oldValue: "yamada@example.com",
+      newValue: "sato@example.com",
+    });
+
+    // github_url: 空 → 新値の modified として検出される。
+    const githubChange = changes.find((c) => c.path.join(".") === "github_url");
+    expect(githubChange).toBeDefined();
+    expect(githubChange?.kind).toBe("modified");
+    expect(githubChange?.newValue).toBe("https://github.com/sato");
+
+    // 項目別ロールバックで両フィールドが baseline 値へ戻る。
+    expect(emailChange!.rollback(form).email).toBe("yamada@example.com");
+    expect(githubChange!.rollback(form).github_url).toBe("");
+  });
+
   it("職歴の追加を added として検出する", () => {
     const baseline = buildForm();
     const form = buildForm();

--- a/frontend/src/utils/careerDiff.test.ts
+++ b/frontend/src/utils/careerDiff.test.ts
@@ -14,6 +14,8 @@ import { buildCareerChanges } from "./careerDiff";
 function buildForm(): CareerFormState {
   return structuredClone({
     full_name: "山田 太郎",
+    email: "yamada@example.com",
+    github_url: "",
     career_summary: "サマリー",
     self_pr: "自己PR",
     experiences: [

--- a/frontend/src/utils/careerDiff.ts
+++ b/frontend/src/utils/careerDiff.ts
@@ -283,6 +283,8 @@ export function buildCareerChanges(
   // 並び順は PDF レイアウト（氏名 → 職務要約 → 職務経歴 → 資格 → 自己PR）に合わせる。
   // 左右ペインとサイドバー（変更点 / 校正）の縦順が一致し、突合しやすくなる。
   pushScalar(changes, [], L.FULL_NAME, ["full_name"], form.full_name, baseline.full_name);
+  pushScalar(changes, [], L.EMAIL, ["email"], form.email, baseline.email);
+  pushScalar(changes, [], L.GITHUB_URL, ["github_url"], form.github_url, baseline.github_url);
   pushScalar(changes, [], L.CAREER_SUMMARY, ["career_summary"], form.career_summary, baseline.career_summary);
 
   diffArray(

--- a/frontend/src/utils/careerDraft.ts
+++ b/frontend/src/utils/careerDraft.ts
@@ -34,6 +34,8 @@ function isCareerDraft(value: unknown): value is CareerFormState {
   const v = value as Record<string, unknown>;
   return (
     typeof v.full_name === "string" &&
+    typeof v.email === "string" &&
+    typeof v.github_url === "string" &&
     typeof v.career_summary === "string" &&
     typeof v.self_pr === "string" &&
     Array.isArray(v.experiences) &&

--- a/frontend/tests/payloadBuilders.test.cjs
+++ b/frontend/tests/payloadBuilders.test.cjs
@@ -6,6 +6,8 @@ const { buildCareerPayload } = require("../.test-dist/payloadBuilders.js");
 test("buildCareerPayload trims data and keeps only non-empty technology stacks", () => {
   const payload = buildCareerPayload({
     full_name: "  山田 太郎  ",
+    email: "  yamada@example.com  ",
+    github_url: "  https://github.com/yamada  ",
     career_summary: "  職務要約テスト  ",
     self_pr: "  自己PRテスト  ",
     experiences: [
@@ -68,6 +70,8 @@ test("buildCareerPayload trims data and keeps only non-empty technology stacks",
   });
 
   assert.equal(payload.full_name, "山田 太郎");
+  assert.equal(payload.email, "yamada@example.com");
+  assert.equal(payload.github_url, "https://github.com/yamada");
   assert.equal(payload.career_summary, "職務要約テスト");
   assert.equal(payload.self_pr, "自己PRテスト");
   assert.equal(payload.experiences.length, 1);
@@ -114,6 +118,8 @@ test("buildCareerPayload throws when 離職で終了年月がない", () => {
     () =>
       buildCareerPayload({
         full_name: "山田 太郎",
+        email: "yamada@example.com",
+        github_url: "",
         career_summary: "職務要約",
         self_pr: "自己PR",
         experiences: [
@@ -140,6 +146,8 @@ test("buildCareerPayload throws when a 資格 is partially filled", () => {
     () =>
       buildCareerPayload({
         full_name: "山田 太郎",
+        email: "yamada@example.com",
+        github_url: "",
         career_summary: "要約",
         self_pr: "自己PR",
         experiences: [],


### PR DESCRIPTION
## 概要

職務経歴書（Resume）に連絡先フィールド（**email** / **github**）を追加し、PDF・Markdown 出力でリンク表示できるようにします。あわせて、保存前の差分確認モーダルの表示崩れを修正します。

## 変更内容

### 連絡先フィールドの追加（contact / email / github）
- `schemas/resume.py`: `email`（必須）/ `github_url`（任意・`https://github.com/` 始まりを検証）を追加
- migration **0043** で `resumes` テーブルに contact カラムを追加
- フォーム（`CareerBasicInfoSection`）/ `payloadBuilders` / dirty 判定 / 差分プレビューに email・github を反映
- OpenAPI 型再生成（`frontend/src/api/generated.ts`）

### PDF / Markdown のラベル・リンク表示
- 連絡先ラベルを **`email`** / **`github`** に統一
- github URL をハイパーリンク表示に
  - PDF: `<a class="meta-link">`（青 `#0066cc`・下線）
  - Markdown: `[URL](URL)` 記法
- `data-fp="github_url"` は `<a>` に付与（差分ハイライトは `[data-fp]` 全要素対象のため維持）

### 差分確認モーダルの表示修正
- `CareerDiffModal` の変更サマリが多いとき、行が暗黙の `auto` で伸びてモーダル（`overflow:hidden`）から clip され、ロールバック/操作ボタンが見えなくなる不具合を修正
- `.body` の `grid-template-rows: minmax(0, 1fr)` で行高を固定し、サマリ列の `overflow-y:auto` を有効化（全件スクロール可能に）

## テスト
- `make ci` 全 pass（backend lint/test、frontend lint/test 303 件、build）
- codegen drift なし
- PDF/Markdown 生成テストにラベル・リンク化の assert を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email and GitHub URL contact fields to resume profiles.
  * Email is required and validates proper format.
  * GitHub URL is optional; when provided, must be a valid github.com URL.
  * Contact information displays in resume outputs (PDF and Markdown formats).

* **Database**
  * Added email and GitHub URL columns to resume records for persistent storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->