### PR TITLE
feat(web): フロントエンド共通ロガーを追加し console 直書きを移行

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,58 @@
+# backend のローカル開発用環境変数サンプル。
+# 実際の値を入れたうえで backend/.env にコピーして使う（backend/.env は gitignore 対象）。
+# 変数の正本は backend/app/core/env_keys.py、用途は docs/api.md「環境変数」セクションを参照。
+
+# --- データベース（libSQL / Turso） ---
+# compose の libsql サービス（docker network 内）に接続する。
+# Turso Cloud を使う場合はここで URL / トークンを設定する。
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
+
+# --- CORS / 暗号化 / 認証 ---
+CORS_ORIGINS=
+FIELD_ENCRYPTION_KEY=
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# --- Redis（Upstash） ---
+UPSTASH_REDIS_URL=
+UPSTASH_REDIS_TOKEN=
+
+# --- Cookie ---
+COOKIE_SECURE=
+COOKIE_SAMESITE=
+
+# --- 管理 / タスク実行 ---
+ADMIN_TOKEN=
+TASK_RUNNER=
+GCP_PROJECT_ID=
+CLOUD_TASKS_QUEUE=
+CLOUD_TASKS_LOCATION=
+CLOUD_TASKS_SERVICE_URL=
+CLOUD_TASKS_SERVICE_ACCOUNT=
+ENVIRONMENT=
+INTERNAL_SECRET=
+CALLBACK_BASE_URL=
+TASK_MAX_ATTEMPTS=
+
+# --- DevForge Agent / LLM（ADR-0010 / ADR-0013） ---
+# ローカルは Ollama 上書きで無料動作。実 API で確認したい時は LLM_LOCAL_OLLAMA=0 にしてキーを設定。
+LLM_LOCAL_OLLAMA=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+OPENAI_API_KEY=
+OLLAMA_BASE_URL=
+OLLAMA_MODEL=
+OLLAMA_TIMEOUT_SECONDS=
+
+# --- 決済（Stripe Checkout / ADR-0012 Phase 2） ---
+# 未設定なら購入機能は無効。
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# --- ログ / バージョン ---
+LOG_LEVEL=
+LOG_FORMAT=
+APP_VERSION=

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,6 @@
+# web のローカル開発用環境変数サンプル。
+# 実際の値を入れたうえで web/.env にコピーして使う（web/.env は gitignore 対象）。
+# Vite はデフォルトで VITE_ 接頭辞の変数のみ import.meta.env に取り込む。
+
+# API のベース URL。未設定なら "" にフォールバックする（web/src/api/client.ts）。
+VITE_API_BASE_URL=

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -22,6 +22,9 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      // console 直書きを禁止し、ログ出力は utils/logger.ts 経由に統一する。
+      // logger 自身は下の override で例外にしている。
+      "no-console": "error",
       // ts/tsx に日本語リテラルのエラーメッセージを直接書かない。
       // frontend/src/constants/messages.ts の定数を参照すること。
       // 詳細: .claude/rules/frontend/messages.md
@@ -42,12 +45,20 @@ export default tseslint.config(
       ],
     },
   },
+  // utils/logger.ts は console を呼ぶ唯一のモジュール（ログ出力の SSoT）なので例外にする。
+  {
+    files: ["src/utils/logger.ts"],
+    rules: {
+      "no-console": "off",
+    },
+  },
   // テストファイルはフィクスチャ用の throw でリテラルを書くケースがあるため、
-  // メッセージハードコード検知ルールを除外する。
+  // メッセージハードコード検知ルールを除外する。テスト内のデバッグ console も許容する。
   {
     files: ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/test/**/*.{ts,tsx}"],
     rules: {
       "no-restricted-syntax": "off",
+      "no-console": "off",
     },
   },
 );

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 
 import { UI_MESSAGES } from "../constants/messages";
 import { generateErrorId } from "../utils/errorId";
+import { logger } from "../utils/logger";
 import styles from "./ErrorBoundary.module.css";
 
 type Props = { children: ReactNode };
@@ -15,7 +16,7 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error("[ErrorBoundary]", error, info.componentStack);
+    logger.error("ErrorBoundary がレンダリングエラーを捕捉しました", error, info.componentStack);
   }
 
   render() {

--- a/web/src/hooks/useAuthSession.ts
+++ b/web/src/hooks/useAuthSession.ts
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 
 import { getCurrentUser, logout, setOnUnauthorized } from "../api";
 import type { AuthUser } from "../router";
+import { logger } from "../utils/logger";
 
 // 認証チェック不要なパス（未認証が正常な画面）
 const PUBLIC_PATHS = new Set(["/", "/login", "/github/callback"]);
@@ -112,7 +113,7 @@ export function useAuthSession() {
     } catch (error) {
       // サーバ側ログアウトが失敗してもクライアント側のクリアは必ず実行する。
       // 未捕捉の reject を残さないようログだけ出して握る。
-      console.warn("logout API 呼び出しに失敗しました（クライアント側はクリアします）", error);
+      logger.warn("logout API 呼び出しに失敗しました（クライアント側はクリアします）", error);
     } finally {
       sessionStorage.removeItem("auth_user");
       justLoggedOut.current = true;

--- a/web/src/utils/careerDraft.ts
+++ b/web/src/utils/careerDraft.ts
@@ -1,4 +1,5 @@
 import type { CareerFormState } from "../payloadBuilders";
+import { logger } from "./logger";
 
 /**
  * 未ログインで入力した職務経歴書ドラフトを OAuth 往復の間だけ退避するユーティリティ。
@@ -21,7 +22,7 @@ export function saveCareerDraft(form: CareerFormState): void {
   try {
     sessionStorage.setItem(CAREER_DRAFT_KEY, JSON.stringify(form));
   } catch (error) {
-    console.warn("職務経歴書ドラフトの退避に失敗しました", error);
+    logger.warn("職務経歴書ドラフトの退避に失敗しました", error);
   }
 }
 
@@ -51,13 +52,13 @@ export function loadCareerDraft(): CareerFormState | null {
   try {
     parsed = JSON.parse(raw);
   } catch (error) {
-    console.warn("職務経歴書ドラフトの読み出しに失敗しました", error);
+    logger.warn("職務経歴書ドラフトの読み出しに失敗しました", error);
     clearCareerDraft();
     return null;
   }
   // パースは成功したが想定の形でない（旧フォーマット等）場合も破棄する。
   if (!isCareerDraft(parsed)) {
-    console.warn("職務経歴書ドラフトの形式が不正なため破棄します");
+    logger.warn("職務経歴書ドラフトの形式が不正なため破棄します");
     clearCareerDraft();
     return null;
   }

--- a/web/src/utils/logger.test.ts
+++ b/web/src/utils/logger.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * logger は `import.meta.env.PROD` をモジュール評価時に読むため、環境を切り替えるたびに
+ * env をスタブしてからモジュールキャッシュを破棄し、動的 import で再評価する。
+ */
+async function loadLogger(prod: boolean) {
+  vi.stubEnv("PROD", prod);
+  vi.resetModules();
+  return (await import("./logger")).logger;
+}
+
+describe("logger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("dev では全レベルが対応する console を呼ぶ", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const logger = await loadLogger(false);
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("本番では debug / info を抑制し warn / error は出力する", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const logger = await loadLogger(true);
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("プレフィックスと追加引数を console へ渡す", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const logger = await loadLogger(false);
+    const cause = new Error("boom");
+    logger.error("失敗しました", cause);
+
+    expect(errorSpy).toHaveBeenCalledWith("[DevForge]", "失敗しました", cause);
+  });
+});

--- a/web/src/utils/logger.ts
+++ b/web/src/utils/logger.ts
@@ -1,0 +1,48 @@
+/**
+ * フロントエンド共通ロガー。`console.*` を直接呼ぶ代わりにこれを使う。
+ *
+ * ## なぜラッパーか
+ * ログ出力の方針（本番でのレベル抑制・プレフィックス統一）を 1 か所へ集約し、
+ * 各所での console 直書きによる方針のばらつきを防ぐ。console を呼ぶ唯一の
+ * モジュールであり、ESLint の no-console ルールはこのファイルだけ例外にしている。
+ *
+ * ## 環境ゲート
+ * ブラウザ環境のため backend のような Cloud Logging 集約・リモート送信は行わず、
+ * console への出力に徹する。`import.meta.env.PROD`（Vite 本番ビルド）では
+ * `debug` / `info` を抑制し、ユーザーのコンソールを汚さない。`warn` / `error` は
+ * 障害調査に必要なため本番でも残す。
+ *
+ * ## 機密情報
+ * ロガーは受け取った引数をそのまま console へ渡すだけ。氏名・メール・トークン等の
+ * PII を渡さない責務は呼び出し側にある（`.claude/rules/security.md`）。
+ */
+
+/** 出力時に付与する統一プレフィックス。 */
+const PREFIX = "[DevForge]";
+
+/** 本番ビルドかどうか。debug / info の抑制判定に使う。 */
+const isProd = import.meta.env.PROD;
+
+export const logger = {
+  /** 開発時の詳細ログ。本番では抑制される。 */
+  debug(message: string, ...args: unknown[]): void {
+    if (isProd) return;
+    console.debug(PREFIX, message, ...args);
+  },
+
+  /** 一般的な情報ログ。本番では抑制される。 */
+  info(message: string, ...args: unknown[]): void {
+    if (isProd) return;
+    console.info(PREFIX, message, ...args);
+  },
+
+  /** 警告ログ。本番でも出力する。 */
+  warn(message: string, ...args: unknown[]): void {
+    console.warn(PREFIX, message, ...args);
+  },
+
+  /** エラーログ。本番でも出力する。 */
+  error(message: string, ...args: unknown[]): void {
+    console.error(PREFIX, message, ...args);
+  },
+};


### PR DESCRIPTION
## 背景

backend には `backend/app/core/logging_utils.py` の構造化ロガーがある一方、web 側には専用ロガーが無く `console.warn` / `console.error` が 5 箇所に散在していた。ログ出力方針（本番でのレベル抑制・プレフィックス統一）が各所バラバラで、今後 console 直書きが増えても検知できない状態だった。

web にもロガーを SSoT として用意し、既存箇所を移行、ESLint で直接 console 利用を禁止して再発防止する。

## 変更内容

- **`web/src/utils/logger.ts`（新規）**: console ラッパー。`debug` / `info` / `warn` / `error` を提供。`import.meta.env.PROD` で本番ビルド時は `debug` / `info` を抑制し、`warn` / `error` は障害調査用に残す。統一プレフィックス `[DevForge]` を付与
- **既存 console.* 5 箇所を移行**: `careerDraft.ts`（3）/ `ErrorBoundary.tsx`（1）/ `useAuthSession.ts`（1）→ `logger.*`
- **`web/eslint.config.js`**: `no-console: error` を追加し直書きを禁止。`logger.ts` とテストのみ override で例外
- **`web/src/utils/logger.test.ts`（新規）**: dev 全出力 / 本番抑制 / プレフィックス・引数受け渡しの 3 ケース

## 設計判断

- ブラウザ環境のため backend のような Cloud Logging 集約・リモート送信は行わず、**console ラッパー + 環境ゲート**に徹した（事前にユーザー確認済み）
- ログ文言は `messages.ts` の SSoT 対象外（ログ用途の console は検知から除外されている）のため定数化していない

## 確認

- ✅ `make lint-web` / `make lint-web-messages`（`no-console` 違反は `logger.ts` 以外 0 件 = 移行漏れなし）
- ✅ `make build-web`（tsc 型エラーなし）
- ✅ `make test-web` 388/388 pass
- E2E は不要（ページ / ルート / 認証フロー / レイアウトの変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)