### PR TITLE
chore(ci): Renovate を導入し依存更新を自動化

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,82 @@
+{
+  // Renovate 設定の正本。詳細: ADR-0014 / docs/development.md
+  // コメントを日本語で残すため JSON5 を採用している。
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    // すべての更新提案を Dependency Dashboard（Issue）に集約して一覧管理する
+    ":dependencyDashboard",
+    // docker イメージは tag だけでなく digest で固定する（再現性・サプライチェーン対策）
+    "docker:pinDigests",
+    // GitHub Actions を SHA(digest) ピン留めで維持する（既存運用に合わせる）
+    "helpers:pinGitHubActionDigests",
+  ],
+
+  timezone: "Asia/Tokyo",
+  // 起票ノイズを抑えるため、毎週月曜の朝に更新 PR をまとめて作る
+  schedule: ["before 9am on monday"],
+  labels: ["dependencies"],
+
+  // このリポジトリは == / SHA 固定でサプライチェーンに慎重な方針のため、
+  // 自動マージは行わない。全 PR を人間がレビューしてマージする。
+  automerge: false,
+
+  // 一度に出す PR 数を制限してレビュー負荷を抑える
+  prConcurrentLimit: 8,
+  prHourlyLimit: 4,
+
+  // lockfile / locked input を定期的にリフレッシュする
+  // （package-lock.json / flake.lock / .terraform.lock.hcl）
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 9am on monday"],
+  },
+
+  // 脆弱性アラートは優先度を上げて即時起票（pip-audit の後追いを先回りで補強）
+  vulnerabilityAlerts: {
+    labels: ["dependencies", "security"],
+    // schedule を空にしてスケジュール制限を外し、検知次第すぐ PR を作る
+    schedule: [],
+  },
+
+  packageRules: [
+    {
+      // GitHub Actions: 既存の digest + "# v4" コメント形式を維持する
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      groupName: "github-actions",
+    },
+    {
+      // Python (backend/requirements.txt): == 完全固定を維持して版上げ PR を出す。
+      // CVE コメント付き行（anthropic / google-genai / starlette 等）も対象。
+      matchManagers: ["pip_requirements"],
+      rangeStrategy: "pin",
+    },
+    {
+      // OpenTofu/Terraform: versions.tf の ~> 制約と各 env の .terraform.lock.hcl を更新
+      matchManagers: ["terraform"],
+      groupName: "terraform providers",
+    },
+    {
+      // docker-compose の libsql-server は :latest 固定のため tag では追従できない。
+      // docker:pinDigests により digest 固定で運用する（version 概念が無い点に留意）。
+      matchManagers: ["docker-compose"],
+      matchPackageNames: ["ghcr.io/tursodatabase/libsql-server"],
+      pinDigests: true,
+    },
+    {
+      // Nix: flake.lock の locked input（nixpkgs unstable / flake-utils）を追従。
+      // Mend hosted app では nix manager が動作する。
+      matchManagers: ["nix"],
+      groupName: "nix flake.lock",
+    },
+    {
+      // web の devDependencies は minor/patch を 1 PR にまとめてレビュー負荷を下げる
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "web devDependencies (non-major)",
+    },
+  ],
+}

--- a/docs/adr/0014-renovate-dependency-automation.md
+++ b/docs/adr/0014-renovate-dependency-automation.md
@@ -1,0 +1,69 @@
+# ADR-0014: Renovate による依存更新の自動化
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+DevForge は依存をすべて「固定」運用している。GitHub Actions は SHA(digest) ピン留め
+（`uses: actions/checkout@34e1148... # v4`）、Python は `backend/requirements.txt` で
+`==` 完全固定、infra プロバイダは `~>` 制約 + `.terraform.lock.hcl`、Nix は `flake.lock`
+で固定している。これはサプライチェーン攻撃（レンジ内 yank / 侵害バージョンの混入）に
+対して安全な一方で、**固定したバージョンを追従する仕組みが無い**という弱点があった。
+
+- 古いバージョンに固定され続け、機能改善・バグ修正・非互換のないセキュリティ修正を取り
+  こぼす。
+- CVE 対応が CI の pip-audit による検知頼みで、後追いになる。
+- 追従が手作業のため、更新が後回しになりがちで、いざ上げる時の差分が大きくなる。
+
+Dependabot / Renovate のいずれも未導入だったため、依存更新を自動で提案する仕組みを
+入れることにした。
+
+## 決定内容
+
+**Renovate（Mend hosted GitHub App）を導入する。** 固定運用は維持したまま、更新の
+「提案（PR 起票）」だけを自動化する。
+
+- 設定の正本は `.github/renovate.json5`（コメントを日本語で残すため JSON5）。
+- 対象エコシステム: github-actions / pip(requirements) / npm / terraform /
+  docker・docker-compose / nix の 6 種。
+- 固定方式は維持する:
+  - github-actions は `pinDigests: true` で digest 固定 + `# v4` コメントを継続。
+  - pip は `rangeStrategy: "pin"` で `==` 固定を維持。
+  - docker は `docker:pinDigests` で digest 固定。
+  - nix は `flake.lock` の locked input を追従。
+- `vulnerabilityAlerts` を優先起票し、pip-audit の後追いを Renovate の先回りで補強する。
+- すべての更新は Dependency Dashboard（Issue）で一覧管理する。
+- **自動マージは行わない。** 全 PR を人間がレビューし、CI green を確認して手動マージする。
+
+## 代替案
+
+- **Dependabot**: GitHub 純正で導入は容易だが、(1) Nix manager が無い、(2) monorepo の
+  グルーピングや digest pin 維持の柔軟性が Renovate に劣る。本リポジトリは Nix を含む
+  多エコシステム構成のため Renovate を採用した。
+- **セルフホスト Renovate（GitHub Action で cron 実行）**: トークン・権限・ランナーを
+  自前管理する必要があり、特に Nix manager 用に nix 入りランナーの用意が要る。hosted
+  app なら nix がサポート済みで運用負荷が小さいため採用しなかった。
+- **導入しない（現状維持）**: 追従の取りこぼしと CVE 後追いの課題が解消しないため却下。
+
+## トレードオフ・既知のリスク
+
+- 定期的に更新 PR が起票され、レビュー工数が発生する（`schedule` / `prConcurrentLimit`
+  / devDependencies のグルーピングで負荷を抑制）。
+- 自動マージしないため、PR を放置すると追従が滞る運用リスクは残る。
+- `ghcr.io/tursodatabase/libsql-server:latest` は tag 固定不可のため digest 運用となり、
+  tag ベースの版差分は追えない。
+- Renovate App のインストール（リポジトリへの権限付与）は GitHub 上の手動操作が必要。
+
+## 将来の移行条件
+
+- レビュー負荷が高い場合、`lockfile` / `digest` など低リスク更新に限定した自動マージの
+  導入を検討する（最初から有効化はしない）。
+- Nix manager の hosted サポートに問題が出た場合は、セルフホスト Action 方式へ切り替える。
+
+## 関連リンク
+
+- 設定: `.github/renovate.json5`
+- 関連方針: `.claude/rules/common/duplication.md`（環境変数・バージョン固定の SSoT）
+- Renovate ドキュメント: https://docs.renovatebot.com/

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## 概要

依存更新を自動追従する仕組みが無かった（Dependabot / Renovate 未導入）課題に対し、**Renovate（Mend hosted app）** を導入する。固定運用は維持したまま、更新の **PR 起票のみ自動化** する。

採用判断の詳細は `docs/adr/0014-renovate-dependency-automation.md` を参照。

## 対象エコシステム（6 manager）

| manager | 対象 | 固定方式の維持 |
|---|---|---|
| github-actions | `.github/workflows/*.yml` | `pinDigests`（SHA + `# v4` コメント継続） |
| pip_requirements | `backend/requirements.txt` | `rangeStrategy: pin`（`==` 維持） |
| npm | `web/package.json` + lock | range + lockfile 更新（devDeps minor/patch はグルーピング） |
| terraform | `infra/.../versions.tf` + 各 env lock | `~>` + lock 更新 |
| docker / docker-compose | `backend/Dockerfile`, `docker-compose.yml` | `docker:pinDigests`（digest 固定） |
| nix | `flake.nix` + `flake.lock` | locked input 追従 |

## 方針

- **自動マージなし** — 全 PR を人間レビュー（慎重なサプライチェーン方針に合わせる）
- `:dependencyDashboard` で全更新を Issue 一覧管理
- `vulnerabilityAlerts` を優先起票し pip-audit の後追いを先回りで補強
- `lockFileMaintenance` 有効（package-lock / flake.lock / .terraform.lock.hcl をリフレッシュ）
- 起票ノイズ抑制: 毎週月曜朝の `schedule` + `prConcurrentLimit` / `prHourlyLimit`

## 検証

- Renovate 公式 validator で設定の妥当性を確認済み（`Config validated successfully`）
- アプリコード・codegen 正本に変更なしのため `make ci` は非該当

## マージ後の手動ステップ ⚠️

実際に稼働させるには、**GitHub で Mend Renovate App をこのリポジトリにインストール**する必要がある（GitHub App の権限付与はブラウザ操作）。設定ファイルが既にあるため onboarding PR はスキップされ、Dependency Dashboard Issue が立つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update proposals to streamline library and dependency management
* **Documentation**
  * Added architectural decision record documenting the dependency automation strategy, including update grouping and security alert prioritization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->