### PR TITLE
docs(ci): renovate.json5 のコメント参照先を ADR に修正

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
-  // Renovate 設定の正本。詳細: ADR-0014 / docs/development.md
+  // Renovate 設定の正本。詳細: ADR-0014 / docs/adr/0014-renovate-dependency-automation.md
   // コメントを日本語で残すため JSON5 を採用している。
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 


### PR DESCRIPTION
## 概要

`.github/renovate.json5` の冒頭コメントが、設定の詳細記載先として誤って `docs/development.md` を参照していた（同ファイルには Renovate の記載を入れていない）。正しい記載先である ADR-0014 のファイルパスに修正する。

## 変更

```diff
- // Renovate 設定の正本。詳細: ADR-0014 / docs/development.md
+ // Renovate 設定の正本。詳細: ADR-0014 / docs/adr/0014-renovate-dependency-automation.md
```

コメント1行のみの修正で、設定値・挙動への影響はなし。

## 検証

- Renovate 公式 validator で再チェック済み（`Config validated successfully`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)