### PR TITLE
docs: 使用 OSS 一覧 (THIRD_PARTY_LICENSES.md) と生成スクリプトを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 	ci \
 	dupe-check dupe-check-html dupe-clean \
 	build-web build-backend deploy-web \
-	gen-redirects codegen-types \
+	gen-redirects codegen-types licenses \
 	migrate migrate-create \
 	infra-fmt infra-fmt-check infra-validate-dev infra-validate-stg infra-validate-prod infra-validate \
 	clean
@@ -55,6 +55,7 @@ help:
 	@echo "  deploy-web   Cloudflare Pages へビルド＆デプロイ (CLOUD_RUN_URL=... 指定可)"
 	@echo "  gen-redirects     Cloudflare Pages 用 _redirects を生成 (CLOUD_RUN_URL=... 指定可)"
 	@echo "  codegen-types     OpenAPI から web 型 (src/api/generated.ts) を再生成 (ADR-0007)"
+	@echo "  licenses          使用 OSS の一覧 (THIRD_PARTY_LICENSES.md) を再生成"
 	@echo ""
 	@echo "マイグレーション"
 	@echo "  migrate           alembic upgrade head"
@@ -196,6 +197,16 @@ gen-redirects:
 # WeasyPrint 等のネイティブ依存解決が必要なため Nix devshell 経由で実行する。
 codegen-types:
 	nix develop --command bash -c "set -e; cd backend && .venv/bin/python scripts/export_openapi.py && cd ../web && node scripts/gen-types.mjs"
+
+# ------------------------------------------------------------------ #
+# 使用 OSS ライセンス一覧
+# ------------------------------------------------------------------ #
+
+# 直接依存 OSS の一覧と各ライセンスを web/package.json・backend/requirements.txt
+# から収集し THIRD_PARTY_LICENSES.md を再生成する。importlib.metadata を使うため
+# backend の依存がインストール済みの Nix devshell 経由で実行する。
+licenses:
+	nix develop --command bash -c "backend/.venv/bin/python scripts/gen-third-party-licenses.py"
 
 # ------------------------------------------------------------------ #
 # マイグレーション

--- a/README.md
+++ b/README.md
@@ -143,3 +143,9 @@ graph TB
     SA -->|"実行権限"| CloudRun
     SA -->|"secretAccessor"| Secrets
 ```
+
+## 使用 OSS / ライセンス表記
+
+DevForge は多くのオープンソースソフトウェアに支えられています。直接依存している OSS の一覧と各ライセンス・配布元へのリンクは [THIRD_PARTY_LICENSES.md](./THIRD_PARTY_LICENSES.md) にまとめています（各 OSS の権利はそれぞれの著作権者に帰属します）。
+
+依存を追加・更新した際は `make licenses` で再生成してください。

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,101 @@
+# サードパーティライセンス / 使用 OSS
+
+DevForge は多くのオープンソースソフトウェア（OSS）に支えられています。
+本ファイルは DevForge が **直接依存している** OSS の一覧と、それぞれのライセンス・
+配布元へのリンクをまとめたものです（謝辞および attribution を兼ねます）。
+
+- ここに列挙した各 OSS の著作権・権利は、それぞれの著作権者に帰属します。
+- 一覧は直接依存（自分で選んで導入したライブラリ）が対象です。推移的依存は含みません。
+- ライセンス種別は各パッケージのメタデータから自動収集しています（手書きの推測ではありません）。
+- **依存を追加・更新したら `make licenses` で本ファイルを再生成してください。** 手動編集は不要です。
+
+> 注: 本ファイルは依存 OSS のライセンス表記であり、DevForge 本体のライセンスを定めるものではありません。
+
+## Frontend（ランタイム / バンドルに同梱）
+
+| ライブラリ | バージョン | ライセンス |
+|---|---|---|
+| [@reduxjs/toolkit](https://redux-toolkit.js.org) | 2.12.0 | MIT |
+| [dompurify](https://github.com/cure53/DOMPurify) | 3.4.10 | (MPL-2.0 OR Apache-2.0) |
+| [marked](https://marked.js.org) | 18.0.5 | MIT |
+| [react](https://react.dev/) | 19.2.7 | MIT |
+| [react-dom](https://react.dev/) | 19.2.7 | MIT |
+| [react-pdf](https://github.com/wojtekmaj/react-pdf) | 10.4.1 | MIT |
+| [react-redux](https://github.com/reduxjs/react-redux) | 9.3.0 | MIT |
+| [react-router-dom](https://github.com/remix-run/react-router) | 7.18.0 | MIT |
+| [recharts](https://github.com/recharts/recharts) | 3.8.1 | MIT |
+| [redux-persist](https://github.com/rt2zz/redux-persist#readme) | 6.0.0 | MIT |
+
+## Frontend（ビルド・開発ツール）
+
+| ライブラリ | バージョン | ライセンス |
+|---|---|---|
+| [@eslint/js](https://eslint.org) | 10.0.1 | MIT |
+| [@playwright/test](https://playwright.dev) | 1.61.0 | Apache-2.0 |
+| [@testing-library/jest-dom](https://github.com/testing-library/jest-dom#readme) | 6.9.1 | MIT |
+| [@testing-library/react](https://github.com/testing-library/react-testing-library#readme) | 16.3.2 | MIT |
+| [@testing-library/user-event](https://github.com/testing-library/user-event#readme) | 14.6.1 | MIT |
+| [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node) | 25.9.3 | MIT |
+| [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) | 19.2.17 | MIT |
+| [@types/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom) | 19.2.3 | MIT |
+| [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#readme) | 6.0.2 | MIT |
+| [@vitest/coverage-v8](https://vitest.dev/guide/coverage) | 4.1.9 | MIT |
+| [concurrently](https://github.com/open-cli-tools/concurrently) | 10.0.3 | MIT |
+| [eslint](https://eslint.org) | 10.5.0 | MIT |
+| [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#readme) | 10.1.8 | MIT |
+| [eslint-plugin-react-hooks](https://react.dev/) | 7.1.1 | MIT |
+| [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) | 0.5.3 | MIT |
+| [express](https://expressjs.com/) | 5.2.1 | MIT |
+| [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#readme) | 4.1.1 | MIT |
+| [jsdom](https://github.com/jsdom/jsdom) | 29.1.1 | MIT |
+| [msw](https://mswjs.io) | 2.14.6 | MIT |
+| [openapi-typescript](https://openapi-ts.dev) | 7.13.0 | MIT |
+| [playwright](https://playwright.dev) | 1.61.0 | Apache-2.0 |
+| [prettier](https://prettier.io) | 3.8.4 | MIT |
+| [typescript](https://www.typescriptlang.org/) | 5.9.3 | Apache-2.0 |
+| [typescript-eslint](https://typescript-eslint.io/packages/typescript-eslint) | 8.61.1 | MIT |
+| [vite](https://vite.dev) | 8.0.16 | MIT |
+| [vitest](https://vitest.dev) | 4.1.9 | MIT |
+| [wrangler](https://github.com/cloudflare/workers-sdk#readme) | 4.101.0 | MIT OR Apache-2.0 |
+
+## Backend（ランタイム）
+
+| ライブラリ | バージョン | ライセンス |
+|---|---|---|
+| [alembic](https://alembic.sqlalchemy.org) | 1.18.4 | MIT |
+| [anthropic](https://github.com/anthropics/anthropic-sdk-python) | 0.111.0 | MIT License |
+| [fastapi](https://github.com/fastapi/fastapi) | 0.138.0 | MIT |
+| [google-cloud-storage](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage) | 3.12.0 | Apache Software License |
+| [google-cloud-tasks](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-tasks) | 2.22.0 | Apache Software License |
+| [google-genai](https://github.com/googleapis/python-genai) | 2.9.0 | Apache-2.0 |
+| [httpx](https://github.com/encode/httpx) | 0.28.1 | BSD License |
+| [markdown](https://Python-Markdown.github.io/) | 3.10.2 | BSD-3-Clause |
+| [openai](https://github.com/openai/openai-python) | 2.43.0 | Apache Software License |
+| [pandas](https://pandas.pydata.org) | 3.0.3 | BSD License |
+| [pyasn1](https://github.com/pyasn1/pyasn1) | 0.6.3 | BSD-2-Clause |
+| [pydantic](https://github.com/pydantic/pydantic) | 2.13.4 | MIT |
+| [pydyf](https://www.courtbouillon.org/pydyf) | 0.12.1 | BSD License |
+| [PyGithub](https://github.com/pygithub/pygithub) | 2.9.1 | GNU Library or Lesser General Public License (LGPL) |
+| [python-dotenv](https://github.com/theskumar/python-dotenv) | 1.2.2 | BSD-3-Clause |
+| [python-jose](http://github.com/mpdavis/python-jose) | 3.5.0 | MIT License |
+| [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.32 | Apache-2.0 |
+| [redis](https://github.com/redis/redis-py) | 8.0.0 | MIT |
+| [reportlab](https://www.reportlab.com/) | 5.0.0 | BSD License |
+| [slowapi](https://github.com/laurents/slowapi) | 0.1.10 | MIT License |
+| [sqlalchemy](https://www.sqlalchemy.org) | 2.0.51 | MIT |
+| [sqlalchemy-libsql](https://github.com/tursodatabase/libsql-sqlalchemy) | 0.2.0 | MIT License |
+| [starlette](https://github.com/Kludex/starlette) | 1.3.1 | BSD-3-Clause |
+| [stripe](https://stripe.com/) | 15.2.1 | MIT License |
+| [uvicorn](https://uvicorn.dev/) | 0.49.0 | BSD-3-Clause |
+| [weasyprint](https://weasyprint.org/) | 69.0 | BSD License |
+
+## Backend（開発ツール）
+
+| ライブラリ | バージョン | ライセンス |
+|---|---|---|
+| [autopep8](https://github.com/hhatto/autopep8) | 2.3.2 | MIT License |
+| [black](https://github.com/psf/black) | 26.5.1 | MIT |
+| [isort](https://pycqa.github.io/isort/index.html) | 8.0.1 | MIT |
+| [pytest](https://docs.pytest.org/en/latest/) | 9.1.1 | MIT |
+| [pytest-cov](https://pypi.org/project/pytest-cov/) | 7.1.0 | MIT |
+| [ruff](https://docs.astral.sh/ruff) | 0.15.18 | MIT |

--- a/scripts/gen-third-party-licenses.py
+++ b/scripts/gen-third-party-licenses.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""THIRD_PARTY_LICENSES.md を再生成する。
+
+DevForge が直接依存する OSS（自分で選んで入れたライブラリ）の一覧と
+ライセンス・リンクを SSoT（web/package.json, backend/requirements.txt）から
+収集し、ルートの THIRD_PARTY_LICENSES.md へ出力する。
+
+- Frontend: web/node_modules/<pkg>/package.json を読む（オフライン・追加依存なし）
+- Backend: importlib.metadata でインストール済みパッケージのメタデータを読む
+
+依存を追加したら `make licenses` で再生成すること。
+nix devshell 経由（backend/.venv の python）で実行する前提。
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as imd
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WEB = ROOT / "web"
+OUTPUT = ROOT / "THIRD_PARTY_LICENSES.md"
+
+# requirements.txt のうち開発専用ツール（ランタイムには載らない）
+BACKEND_DEV_TOOLS = {
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "black",
+    "isort",
+    "autopep8",
+}
+
+
+def _clean_url(url: str | None) -> str:
+    """git+https://...​.git のような URL を https の閲覧用 URL に正規化する。"""
+    if not url:
+        return ""
+    url = url.strip()
+    # npm の repository ショートハンド (github:owner/repo, gitlab:..., bitbucket:...)
+    m = re.match(r"^(github|gitlab|bitbucket):(.+)$", url)
+    if m:
+        host = {"github": "github.com", "gitlab": "gitlab.com", "bitbucket": "bitbucket.org"}[m.group(1)]
+        url = f"https://{host}/{m.group(2)}"
+    url = re.sub(r"^git\+", "", url)
+    url = re.sub(r"^git://", "https://", url)
+    url = re.sub(r"^ssh://git@", "https://", url)
+    url = re.sub(r"\.git$", "", url)
+    return url
+
+
+def _npm_license(pkg: dict) -> str:
+    """npm の package.json から SPDX ライセンス表記を取り出す。"""
+    lic = pkg.get("license")
+    if isinstance(lic, str):
+        return lic
+    if isinstance(lic, dict):
+        return lic.get("type", "")
+    # 旧形式: licenses: [{type, url}, ...]
+    licenses = pkg.get("licenses")
+    if isinstance(licenses, list):
+        types = [x.get("type", "") for x in licenses if isinstance(x, dict)]
+        return " OR ".join(t for t in types if t)
+    return ""
+
+
+def _npm_url(pkg: dict) -> str:
+    homepage = pkg.get("homepage")
+    if homepage:
+        return _clean_url(homepage)
+    repo = pkg.get("repository")
+    if isinstance(repo, dict):
+        return _clean_url(repo.get("url"))
+    if isinstance(repo, str):
+        return _clean_url(repo)
+    return ""
+
+
+def collect_npm(dep_names: list[str]) -> list[tuple[str, str, str, str]]:
+    """(name, version, license, url) のリストを返す。"""
+    rows: list[tuple[str, str, str, str]] = []
+    for name in sorted(dep_names, key=str.lower):
+        pkg_json = WEB / "node_modules" / name / "package.json"
+        if not pkg_json.exists():
+            rows.append((name, "—", "要確認 (未インストール)", f"https://www.npmjs.com/package/{name}"))
+            continue
+        pkg = json.loads(pkg_json.read_text(encoding="utf-8"))
+        version = pkg.get("version", "—")
+        lic = _npm_license(pkg) or "要確認"
+        url = _npm_url(pkg) or f"https://www.npmjs.com/package/{name}"
+        rows.append((name, version, lic, url))
+    return rows
+
+
+def _py_license(dist_name: str) -> tuple[str, str, str]:
+    """(version, license, url) を importlib.metadata から取り出す。"""
+    try:
+        meta = imd.metadata(dist_name)
+    except imd.PackageNotFoundError:
+        return ("—", "要確認 (未インストール)", f"https://pypi.org/project/{dist_name}/")
+
+    version = meta.get("Version", "—")
+
+    # ライセンス解決の優先順位:
+    #   1. License-Expression（PEP 639 の SPDX。最もクリーン）
+    #   2. License Classifier の末尾セグメント
+    #   3. License フィールド（短い場合のみ。全文が入っていることがあるため除外）
+    expr = meta.get("License-Expression")
+    classifiers = [
+        c.split("::")[-1].strip()
+        for c in meta.get_all("Classifier", [])
+        if c.startswith("License")
+    ]
+    license_field = meta.get("License")
+    if expr:
+        lic = expr
+    elif classifiers:
+        lic = " / ".join(classifiers)
+    elif license_field and "\n" not in license_field and len(license_field) <= 40:
+        lic = license_field
+    else:
+        lic = "要確認 (プロジェクト参照)"
+
+    # URL 解決: Home-page → Project-URL(Homepage/Source/Repository) → PyPI
+    url = meta.get("Home-page") or ""
+    if not url:
+        for entry in meta.get_all("Project-URL", []):
+            label, _, value = entry.partition(",")
+            if label.strip().lower() in {"homepage", "source", "repository", "source code"}:
+                url = value.strip()
+                break
+    if not url:
+        url = f"https://pypi.org/project/{dist_name}/"
+    return (version, lic, _clean_url(url))
+
+
+def parse_requirements() -> list[str]:
+    """requirements.txt から配布名（extras/version 指定を除いた名前）を抽出する。"""
+    req = (ROOT / "backend" / "requirements.txt").read_text(encoding="utf-8")
+    names: list[str] = []
+    for line in req.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # 例: uvicorn[standard]==0.34.0 / pydantic[email]==2.10.3 / stripe>=11,<13
+        name = re.split(r"[\[<>=!~ ]", line, maxsplit=1)[0].strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def md_table(rows: list[tuple[str, str, str, str]]) -> str:
+    out = ["| ライブラリ | バージョン | ライセンス |", "|---|---|---|"]
+    for name, version, lic, url in rows:
+        link = f"[{name}]({url})" if url else name
+        out.append(f"| {link} | {version} | {lic} |")
+    return "\n".join(out)
+
+
+def main() -> None:
+    web_pkg = json.loads((WEB / "package.json").read_text(encoding="utf-8"))
+    fe_runtime = collect_npm(list(web_pkg.get("dependencies", {})))
+    fe_dev = collect_npm(list(web_pkg.get("devDependencies", {})))
+
+    backend_names = parse_requirements()
+    be_runtime: list[tuple[str, str, str, str]] = []
+    be_dev: list[tuple[str, str, str, str]] = []
+    for name in sorted(backend_names, key=str.lower):
+        version, lic, url = _py_license(name)
+        row = (name, version, lic, url)
+        (be_dev if name in BACKEND_DEV_TOOLS else be_runtime).append(row)
+
+    doc = f"""# サードパーティライセンス / 使用 OSS
+
+DevForge は多くのオープンソースソフトウェア（OSS）に支えられています。
+本ファイルは DevForge が **直接依存している** OSS の一覧と、それぞれのライセンス・
+配布元へのリンクをまとめたものです（謝辞および attribution を兼ねます）。
+
+- ここに列挙した各 OSS の著作権・権利は、それぞれの著作権者に帰属します。
+- 一覧は直接依存（自分で選んで導入したライブラリ）が対象です。推移的依存は含みません。
+- ライセンス種別は各パッケージのメタデータから自動収集しています（手書きの推測ではありません）。
+- **依存を追加・更新したら `make licenses` で本ファイルを再生成してください。** 手動編集は不要です。
+
+> 注: 本ファイルは依存 OSS のライセンス表記であり、DevForge 本体のライセンスを定めるものではありません。
+
+## Frontend（ランタイム / バンドルに同梱）
+
+{md_table(fe_runtime)}
+
+## Frontend（ビルド・開発ツール）
+
+{md_table(fe_dev)}
+
+## Backend（ランタイム）
+
+{md_table(be_runtime)}
+
+## Backend（開発ツール）
+
+{md_table(be_dev)}
+"""
+    OUTPUT.write_text(doc, encoding="utf-8")
+    print(f"生成しました: {OUTPUT.relative_to(ROOT)}")
+    print(
+        f"  Frontend runtime={len(fe_runtime)} dev={len(fe_dev)} / "
+        f"Backend runtime={len(be_runtime)} dev={len(be_dev)}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

DevForge が直接依存している OSS の謝辞・attribution として `THIRD_PARTY_LICENSES.md` を追加します。一覧は SSoT（`web/package.json` / `backend/requirements.txt`）から自動生成し、手書きの推測を排除します。

stash に WIP で退避されていた成果物を、現行 main（`web/` 構成）上で再生成して PR 化したものです。

## 変更点

- **`THIRD_PARTY_LICENSES.md`**（新規）: 直接依存 OSS の一覧（ライブラリ / バージョン / ライセンス / リンク）
- **`scripts/gen-third-party-licenses.py`**（新規）: 自動生成スクリプト
  - npm: `web/node_modules/<pkg>/package.json` から SPDX を収集（オフライン・追加依存なし）
  - backend: `importlib.metadata` でインストール済みメタデータから収集
- **`Makefile`**: `make licenses` ターゲットを追加（依存追加・更新時に再生成）
- **`README.md`**: 参照セクションを追記

## 生成結果

Frontend runtime=10 / dev=27、Backend runtime=26 / dev=6（計 69 件）を収集。「要確認 / 未インストール」の欠落エントリは無し。

## 検証

- `make licenses` で現 main の依存から再生成し差分を確認
- `ruff check scripts/gen-third-party-licenses.py`: All checks passed

## 運用メモ

推移的依存は対象外（直接依存のみ）。依存を追加・更新したら `make licenses` で再生成してコミットする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)