### PR TITLE
feat(web): アプリバージョンをサイドバーのユーザーメニューに表示

### DIFF
--- a/web/src/components/UserMenu.test.tsx
+++ b/web/src/components/UserMenu.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { UserMenu } from "./UserMenu";
+import { UI_MESSAGES } from "../constants/messages";
+import { APP_VERSION } from "../utils/appVersion";
+
+/** 認証済み状態の UserMenu を描画する最小ヘルパー。 */
+function renderMenu() {
+  return render(
+    <UserMenu
+      isAuthenticated={true}
+      username="testuser"
+      theme="light"
+      onToggleTheme={() => {}}
+      onLogout={() => {}}
+      onLogin={() => {}}
+    />,
+  );
+}
+
+describe("UserMenu", () => {
+  it("メニューを開くとフッターにコピーライトとアプリバージョンを併記する", () => {
+    renderMenu();
+    // メニューはトリガー押下で初めて開く（フッターはその中にある）。
+    fireEvent.click(screen.getByRole("button", { name: /testuser/ }));
+    // vitest 環境では VITE_APP_VERSION 未注入のため APP_VERSION は "dev" になる。
+    expect(
+      screen.getByText(`${UI_MESSAGES.COPYRIGHT} · ${APP_VERSION}`),
+    ).toBeTruthy();
+  });
+});

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -8,6 +8,7 @@ import {
   UI_MESSAGES,
 } from "../constants/messages";
 import type { Theme } from "../hooks/useTheme";
+import { APP_VERSION } from "../utils/appVersion";
 import { GitHubMarkIcon } from "./icons/GitHubMarkIcon";
 import styles from "./UserMenu.module.css";
 
@@ -134,7 +135,9 @@ export function UserMenu({
             </svg>
             <span className={styles.srOnly}>{UI_MESSAGES.OPENS_IN_NEW_TAB}</span>
           </a>
-          <div className={styles.menuFooter}>{UI_MESSAGES.COPYRIGHT}</div>
+          <div className={styles.menuFooter}>
+            {UI_MESSAGES.COPYRIGHT} · {APP_VERSION}
+          </div>
         </div>
       )}
       {isAuthenticated ? (

--- a/web/src/utils/appVersion.ts
+++ b/web/src/utils/appVersion.ts
@@ -1,0 +1,2 @@
+/** ビルド時に注入されるアプリバージョン（git tag 由来 / 未注入時は dev）。 */
+export const APP_VERSION: string = import.meta.env.VITE_APP_VERSION ?? "dev";


### PR DESCRIPTION
## 概要

プロダクトのバージョンを画面（サイドバーのユーザーメニュー内フッター）に表示する。

調査の結果、バージョン管理の配線は半分だけ既に存在していた:
- `deploy.yml` が `git describe --tags`（無ければ `dev`）で `APP_VERSION` を決定
- backend は `APP_VERSION` をイメージに焼き込み `GET /health` で返す（既に機能）
- web ビルドには `VITE_APP_VERSION` が env で渡っている（届いているが未使用）

**欠けていたのは web 側の表示だけ**だったため、ビルド時注入経路はそのまま使い、表示部分のみを追加した。

## 変更内容

- `web/src/utils/appVersion.ts`（新規）: `APP_VERSION = import.meta.env.VITE_APP_VERSION ?? "dev"`
- `web/src/components/UserMenu.tsx`: フッターのコピーライト横に `· {APP_VERSION}` を併記
- `web/src/components/UserMenu.test.tsx`（新規）: フッター表示の vitest

## 方針メモ

- 表示値は git describe 由来の文字列を**そのまま**出す（タグ `v1.2.3` ならそのまま表示。`v` の二重付与を避けるため自前プレフィックスは付けない）
- backend / infra / OpenAPI スキーマは未変更（codegen 不要）

## 運用前提（コードではない）

現状 git tag が未作成のため、デプロイしても表示は **`dev`** のまま。実バージョンを出すにはリリース時に `git tag -a v0.1.0 -m "..."` → push → deploy が必要。

## 検証

- `make lint-web` / `make lint-web-messages` / `make test-web`（404 pass）/ `make build-web` すべて green
- E2E（Playwright）35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)