### PR TITLE
feat(resume): プロジェクト見出しを構造化情報に集約し業務内容ラベルを廃止

### DIFF
--- a/backend/app/services/markdown/generators/resume_generator.py
+++ b/backend/app/services/markdown/generators/resume_generator.py
@@ -123,9 +123,6 @@ def build_resume_markdown(payload: dict[str, Any]) -> str:
                     role = _a(proj, "role")
                     if role:
                         lines.append(field_line("担当", role))
-                    description = _a(proj, "description")
-                    if description:
-                        lines.append(field_line("詳細", description))
                     # 体制（後方互換: 旧 scale → team の正規化は shared に集約）
                     team = normalize_team(proj)
                     if team:
@@ -146,6 +143,11 @@ def build_resume_markdown(payload: dict[str, Any]) -> str:
                     phases = _a(proj, "phases", [])
                     if phases:
                         lines.append(field_line("工程", ", ".join(phases)))
+                    # 詳細（自由記述）は構造化情報（期間/担当/体制/工程）の後に出す。
+                    # PDF 側で構造化情報を見出しに集約し description を本文に置いた構成と揃える。
+                    description = _a(proj, "description")
+                    if description:
+                        lines.append(field_line("詳細", description))
                     stacks = _a(proj, "technology_stacks", [])
                     if stacks:
                         grouped = group_stacks_by_category(stacks)

--- a/backend/app/services/pdf/generators/resume_generator.py
+++ b/backend/app/services/pdf/generators/resume_generator.py
@@ -116,7 +116,9 @@ def _format_team(project) -> str:
 
 def _build_project_html(project, fp: str) -> str:
     """プロジェクト1件分のHTMLを組み立てる（fp = このプロジェクトの data-fp プレフィックス）"""
-    # ヘッダー（3行構成: 期間/プロジェクト名、役割、工程）
+    # 左列の見出し（3行構成: 期間/プロジェクト名、役割/体制、工程）。
+    # 旧実装はテーブル上に独立ヘッダーを置きつつ左列見出しを「業務内容」としていたが、
+    # 同じ情報が上下に重複していたため、構造化情報を左列見出しセルへ集約する。
     name = _a(project, "name")
     periods = _a(project, "periods", [])
     role = _a(project, "role")
@@ -143,12 +145,12 @@ def _build_project_html(project, fp: str) -> str:
         joined = "／".join(_esc(p) for p in phases)
         line3 = f'工程：<span data-fp="{fp}.phases">{joined}</span>'
 
-    header_lines = [ln for ln in [line1, line2, line3] if ln]
-    header_html = ""
-    if header_lines:
-        header_html = '<div class="project-header">' + "<br/>".join(header_lines) + "</div>"
+    # 左列の見出しセルの内容。構造化情報が1つも無い疎データのプロジェクトでは、
+    # 見出しが空の灰色ボックスにならないよう従来通り「業務内容」の文字を出す。
+    info_lines = [ln for ln in [line1, line2, line3] if ln]
+    info_header = "<br/>".join(info_lines) if info_lines else "業務内容"
 
-    # 左カラム: 業務内容
+    # 左カラム本文: 業務内容（自由記述）
     left_parts: list[str] = []
     description = _a(project, "description")
     if description:
@@ -167,10 +169,12 @@ def _build_project_html(project, fp: str) -> str:
     right_content = "<br/>".join(right_parts) if right_parts else "-"
 
     # 体制は表のカラムではなく役割行に併記する（line2 で処理済み）。
+    # 左列見出しに構造化情報（info_header）を入れ、独立ヘッダーは廃止した。
     return (
-        f'<div class="project" data-unit="{fp}">{header_html}'
+        f'<div class="project" data-unit="{fp}">'
         f'<table class="project-table">'
-        f"<thead><tr><th>業務内容</th><th>スキルセット</th></tr></thead>"
+        f'<thead><tr><th class="proj-info">{info_header}</th>'
+        f"<th>スキルセット</th></tr></thead>"
         f'<tbody><tr><td class="desc" data-fp="{fp}.description">{left_content}</td>'
         f'<td class="env" data-fp="{fp}.technology_stacks">{right_content}</td></tr></tbody>'
         f"</table></div>"

--- a/backend/app/services/pdf/templates/resume.css
+++ b/backend/app/services/pdf/templates/resume.css
@@ -130,12 +130,6 @@ h2 {
      分割時の列見出しは project-table の thead で繰り返す。 */
 }
 
-.project-header {
-  font-size: 9pt;
-  font-weight: bold;
-  margin: 2mm 0 1mm 0;
-}
-
 .project-table {
   width: 100%;
   border-collapse: collapse;
@@ -149,6 +143,13 @@ h2 {
   padding: 3px 4px;
   text-align: center;
   font-weight: bold;
+}
+
+/* 左列見出しセル: プロジェクトの構造化情報（期間/役割/工程）を複数行で表示するため
+   中央寄せの単一ラベルではなく左寄せにする。 */
+.project-table th.proj-info {
+  text-align: left;
+  font-size: 9pt;
 }
 
 .project-table td {
@@ -166,7 +167,7 @@ h2 {
   width: 25%;
 }
 
-/* 業務内容カラム内のラベル */
+/* 業務内容（自由記述）本文セル内の段落 */
 .project-table td.desc p {
   margin: 0 0 0.5em 0;
 }

--- a/backend/tests/test_markdown_generator.py
+++ b/backend/tests/test_markdown_generator.py
@@ -169,3 +169,23 @@ def test_it_experience_renders_projects_unchanged() -> None:
     assert "#### 顧客A" in md
     assert "##### API開発" in md
     assert "性能改善を担当" in md
+
+
+def test_project_description_rendered_after_structured_fields() -> None:
+    """詳細（description）は構造化情報（担当/体制/工程）の後に出力される
+    （PDF 側で構造化情報を見出しへ集約し description を本文に置いた構成と揃える）。"""
+    exp = _it_experience()
+    exp["clients"][0]["projects"][0]["phases"] = ["開発", "総合テスト"]
+    payload = {
+        "full_name": "山田 太郎",
+        "career_summary": "要約",
+        "self_pr": "自己PR",
+        "qualifications": [],
+        "experiences": [exp],
+    }
+
+    md = build_resume_markdown(payload)
+
+    # 工程・担当（構造化情報）の後に詳細（description）が来る
+    assert md.index("担当") < md.index("性能改善を担当")
+    assert md.index("工程") < md.index("性能改善を担当")

--- a/backend/tests/test_pdf_generator.py
+++ b/backend/tests/test_pdf_generator.py
@@ -127,12 +127,70 @@ def test_build_html_annotates_data_fp() -> None:
     assert 'data-fp="experiences.0.end_date"' in html
     assert 'data-fp="experiences.0.clients.0.name"' in html
     assert 'data-fp="experiences.0.clients.0.projects.0.role"' in html
+    assert 'data-fp="experiences.0.clients.0.projects.0.periods"' in html
     assert 'data-fp="experiences.0.clients.0.projects.0.technology_stacks"' in html
     assert 'data-fp="qualifications.0.name"' in html
     # 折りたたみ用の項目コンテナ（data-unit）も付与される
     assert 'data-unit="experiences.0"' in html
     assert 'data-unit="experiences.0.clients.0.projects.0"' in html
     assert 'data-unit="qualifications.0"' in html
+
+
+def test_project_structured_info_in_header_cell() -> None:
+    """プロジェクトの構造化情報（期間/名前・役割/体制・工程）は左列見出しセルに集約され、
+    独立ヘッダー（project-header）や「業務内容」ラベルは出力されない。description 本文は残る。"""
+    payload = {
+        "full_name": "山田太郎",
+        "career_summary": "要約",
+        "self_pr": "PR",
+        "qualifications": [],
+        "experiences": [
+            {
+                "company": "Example株式会社",
+                "business_description": "SES事業",
+                "start_date": "2020-04",
+                "end_date": "2024-03",
+                "is_current": False,
+                "is_it_company": True,
+                "clients": [
+                    {
+                        "name": "取引先A",
+                        "has_client": True,
+                        "projects": [
+                            {
+                                "name": "案件X",
+                                "role": "メンバ",
+                                "periods": [
+                                    {"start_date": "2025-09", "end_date": "2026-12"}
+                                ],
+                                "team": {
+                                    "total": "13",
+                                    "members": [{"role": "PM", "count": 1}],
+                                },
+                                "phases": ["開発", "単体テスト", "総合テスト"],
+                                "description": "サービス概要の説明文",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    html = _build_html(payload)
+
+    # 構造化情報は左列見出しセル（th.proj-info）に入る
+    assert 'class="proj-info"' in html
+    # 旧来の独立ヘッダーと「業務内容」ラベルは廃止
+    assert "project-header" not in html
+    assert "<th>業務内容</th>" not in html
+    # 役割・体制・工程・期間が見出しに含まれる
+    assert "工程：" in html
+    assert "体制：" in html
+    assert "役割：" in html
+    # description 本文は左列の本文セルに残る
+    assert "サービス概要の説明文" in html
+    assert 'data-fp="experiences.0.clients.0.projects.0.description"' in html
 
 
 def test_build_html_renders_contact_fields() -> None:


### PR DESCRIPTION
## 概要

職務経歴書 PDF で各プロジェクトのヘッダー情報（期間/プロジェクト名・役割/体制・工程）が、テーブル上の独立ヘッダーと「業務内容」列見出しの両方に重複表示されていた。これを左列の見出しセルへ集約し、「業務内容」ラベルを廃止する。

スクリーンショットで確認した要望:「業務内容」ラベルを削除し、その空いた見出しセルにプロジェクト名・期間・工程・役割を記載する。重複を避けるためテーブル上の独立ヘッダーも廃止して見出しセルに集約。

## 変更内容

- **PDF** (`pdf/generators/resume_generator.py` / `templates/resume.css`)
  - 独立ヘッダー(`project-header`)を廃止
  - 左列見出しを「業務内容」ラベル → 構造化情報(`th.proj-info`, 左寄せ)に置換
  - `description` 本文は左列本文セルに残存。スキルセット列は不変
  - 左右 diff プレビュー用の `data-fp` は全て維持
  - 疎データ時は従来通り「業務内容」をフォールバック表示
- **Markdown** (`markdown/generators/resume_generator.py`)
  - `詳細`(description) を構造化フィールド(期間/担当/体制/工程)の後ろへ移動し、PDF の構成と揃える
- **テスト**
  - PDF: 見出しセル集約・独立ヘッダー廃止・「業務内容」ラベル不在・description 残存を検証
  - Markdown: `詳細` が `工程` より後に出る順序を検証

## 影響範囲 / 確認事項

- 既存 PDF/Markdown レイアウトの変更（破壊的変更）
- スキーマ/ルーター不変のため **codegen・マイグレーションは不要**。web は無変更
- Markdown の reorder は「PDF/Markdown 両方適用」要望を満たすための判断

## 検証

- 生成 PDF を実レンダリングして目視確認（希望レイアウトと一致）
- `ruff` クリーン / backend 全テスト **635 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)