### PR TITLE
docs(intelligence): スキル推論基盤の stale docstring を修正（verify 実装済みに追従）

### DIFF
--- a/backend/app/services/intelligence/skills/__init__.py
+++ b/backend/app/services/intelligence/skills/__init__.py
@@ -1,7 +1,7 @@
 """GitHub 連携スキル推論基盤（ADR-0016）。
 
-discover（言語 / Linguist）+ declare（manifest 宣言）を合流し、3 層モデルへ投入する
-中間表現を組み立てる。verify（import 解析）は後続フェーズ。
+discover（言語 / Linguist）+ declare（manifest 宣言）+ verify（import 解析）を合流し、
+3 層モデルへ投入する中間表現を組み立てる。
 """
 
 from .aggregator import (


### PR DESCRIPTION
## 概要

ADR-0016「GitHub 連携によるスキル推論基盤」のコア決定（D1〜D9）実装完了に伴う、ドキュメント不整合の掃除。

`backend/app/services/intelligence/skills/__init__.py` のモジュール docstring が「verify（import 解析）は後続フェーズ」のままで、**D6（import 解析）が実装済み**の実態と矛盾していた（直近の `feat/skill-verify-import-analysis` で verify ステージが入った）。verify を discover / declare と並ぶ「合流する段」として書き直す。

## 変更内容

- docstring 1 箇所（2 行）のみ。挙動・API・テストへの影響なし。

## 検証

- メイン venv で `ruff check` → All checks passed!
- service モジュールの docstring 変更のため OpenAPI codegen（`make codegen-types`）への影響なし（schemas / routers 不変）。
- 挙動変更が無いためテスト追加は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)