### PR TITLE
fix: mutmut の clean test 失敗を修正（グローバル event loop 汚染の除去）

### DIFF
--- a/.claude/rules/backend/test.md
+++ b/.claude/rules/backend/test.md
@@ -50,3 +50,4 @@ pytest は標準 SQLite + `Base.metadata.create_all` で動くため、**本番�
 - `try / except Exception: pass` をテストコード内で使う（失敗を隠す）
 - `time.sleep` での同期待ち（フレーキーになる。`AsyncMock` / `monkeypatch` を使う）
 - 過剰モック: SQLAlchemy セッション全体をモックする等。実 DB セッションを使うこと
+- **テストで `asyncio.set_event_loop` / `get_event_loop`（グローバル event loop）を触る**: mutmut 3.x は同一プロセスでスイートを複数回実行するため、グローバル loop 状態が実行間に漏れて clean test が `RuntimeError: There is no current event loop` で落ちる（`make mutation-backend` が `Failed to run clean test` で停止した実績）。async は `loop = asyncio.new_event_loop(); try: loop.run_until_complete(...); finally: loop.close()` の分離パターンで実行する（グローバル loop を設定・復元しない）

--- a/backend/tests/security/test_ssrf_github.py
+++ b/backend/tests/security/test_ssrf_github.py
@@ -32,16 +32,18 @@ _MALICIOUS_OWNERS = [
 
 
 def _run(coro):
-    """既存テストの event loop 前提を壊さず非同期関数を実行する。"""
-    original = asyncio.get_event_loop_policy().get_event_loop()
+    """async 関数を専用 event loop で同期実行する（グローバル loop を触らない）。
+
+    mutmut 3.x は同一プロセスで pytest スイートを複数回実行するため、
+    ``asyncio.set_event_loop`` / ``get_event_loop`` でグローバル loop 状態に
+    触れると実行間に汚染が漏れて clean test が落ちる。ローカル loop を作って
+    閉じるだけの分離パターンにして反復実行に対して冪等にする。
+    """
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     try:
         return loop.run_until_complete(coro)
     finally:
         loop.close()
-        # 一時 loop を閉じたら元の loop へ戻す（新規 loop を作って放置すると leak する）。
-        asyncio.set_event_loop(original)
 
 
 @pytest.mark.parametrize("bad", _MALICIOUS_OWNERS)


### PR DESCRIPTION
## 変更概要

`make mutation-backend`（`mutmut run`）がミューテーション本体に入る前の **clean test フェーズで `RuntimeError: There is no current event loop` により落ち、`Failed to run clean test` → `exit(1)`** していた問題を修正する。原因は `tests/security/test_ssrf_github.py` の `_run()` だけがグローバル asyncio event loop を操作していたこと。他 11 個の `_run` と同じ「ローカル loop を作って閉じるだけ」の分離パターンに統一し、mutmut の同一プロセス反復実行に対して冪等にする。

### 原因（詳細）

mutmut 3.x は **同一 Python プロセス内で pytest スイートを複数回**実行する（stats 収集 → clean test 検証 → ミュータント実行）。`test_llm_clients.py` の `asyncio.run()` が終了時にグローバル loop を `None` へ戻す（`_set_called=True` のまま）ため、その壊れた状態が 2 周目のスイート実行に持ち越される。2 周目に SSRF テストの `_run()` が `asyncio.get_event_loop()` を呼ぶと `RuntimeError: There is no current event loop` を送出し、`with pytest.raises(NonRetryableError)` の外へ抜けて `test_fetch_repos_raw_rejects_bad_username_without_http` が失敗していた。

- 全 12 個の `_run` ヘルパのうち、グローバル loop を触るのは本ファイルの 1 つのみ（唯一の汚染源かつ被害者）。
- 再発防止として `.claude/rules/backend/test.md` のアンチパターンに「テストでグローバル event loop を触らない」を追記。

## セルフレビューチェックリスト

### 必須確認

- [x] `make ci` 相当を確認（※本セッション環境に nix が無いため公式 `make` は未実行。同等の venv で **ruff clean** / フルスイート **667 passed** / 同一プロセス 2 回実行で修正前=2 回目 1 failed→修正後=両方 667 passed を確認。実環境では `make ci` / `make mutation-backend` での最終確認を推奨）
- [x] コメント・ドキュメント・エラーメッセージは日本語で記述した

### 条件付き確認

- [x] `app/schemas/` または `app/routers/` の変更: N/A（テストとルール文書のみ、OpenAPI へ影響なし）
- [x] ページ・認証・ナビ・レイアウト変更: N/A
- [x] 新規環境変数: N/A
- [x] `web/src/` の日本語メッセージ: N/A（web 変更なし）

### 破壊的変更

- [x] 破壊的変更なし（プロダクトコード `app/` 無変更。テストの意図・API 契約・DB スキーマに変更なし）

### ADR

- [x] N/A（新規ライブラリ採用・アーキテクチャ変更なし）

## 検証

| 実行形態 | 修正前 | 修正後 |
|---|---|---|
| フルスイート 1 回（別プロセス） | 667 passed | 667 passed |
| **同一プロセスでフルスイート 2 回**（mutmut の stats→clean を再現） | 2 回目 **1 failed** | 両方 **667 passed** |
| ruff（変更ファイル） | — | All checks passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsRavDhjAWMQby1g6gHVyR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by isolating async event loop usage, reducing intermittent failures in repeated test runs.
  * Prevented leftover event loop state from causing runtime errors in clean test sessions.

* **Documentation**
  * Added guidance for safer async testing practices, including using local event loops and closing them properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->