### PR TITLE
refactor(auth): JWT ライブラリを python-jose から PyJWT へ移行し ecdsa 脆弱性を解消

### DIFF
--- a/.claude/rules/backend/auth-security.md
+++ b/.claude/rules/backend/auth-security.md
@@ -8,7 +8,7 @@ paths:
 ## 認証
 
 - **認証方式**: GitHub OAuth のみ。パスワード認証は実装していない（`users` テーブルにパスワード関連カラムは持たない、OAuth 専用設計）
-- **JWT**: `python-jose[cryptography]`、RS256 署名（`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`）
+- **JWT**: `PyJWT[crypto]`、RS256 署名（`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`）
 - **トークン有効期間**:
   - アクセストークン: 15 分（Cookie 名 `access_token`）
   - リフレッシュトークン: 7 日（Cookie 名 `refresh_token`）

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ GitHub活動分析、ブログ連携による発信力を集計
 | AI / LLM | Anthropic Claude / OpenAI GPT / Google Gemini（ユーザー選択式・ADR-0013）、ローカルは Ollama |
 | 決済 | Stripe Checkout（クレジット購入・従量課金 / ADR-0012） |
 | データベース | Turso (libSQL / SQLite 互換、`sqlalchemy-libsql`) |
-| 認証 | JWT Cookie (python-jose), bcrypt, GitHub OAuth |
+| 認証 | JWT Cookie (PyJWT), bcrypt, GitHub OAuth |
 | 暗号化 | Fernet（フィールド暗号化） |
 | PDF出力 | WeasyPrint（職務経歴書）, ReportLab（分析レポート補助） |
 | インフラ | GCP (Cloud Run, Artifact Registry, Secret Manager), Turso, Cloudflare Pages |

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -78,8 +78,8 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | [pydantic](https://github.com/pydantic/pydantic) | 2.13.4 | MIT |
 | [pydyf](https://www.courtbouillon.org/pydyf) | 0.12.1 | BSD License |
 | [PyGithub](https://github.com/pygithub/pygithub) | 2.9.1 | GNU Library or Lesser General Public License (LGPL) |
+| [PyJWT](https://github.com/jpadilla/pyjwt) | 2.13.0 | MIT |
 | [python-dotenv](https://github.com/theskumar/python-dotenv) | 1.2.2 | BSD-3-Clause |
-| [python-jose](http://github.com/mpdavis/python-jose) | 3.5.0 | MIT License |
 | [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.32 | Apache-2.0 |
 | [redis](https://github.com/redis/redis-py) | 8.0.1 | MIT |
 | [reportlab](https://www.reportlab.com/) | 5.0.0 | BSD License |

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -4,8 +4,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import NoReturn
 
+import jwt
 from fastapi import Depends, Request, status
-from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from ...db import get_db
@@ -39,7 +39,7 @@ def validate_jwt_key_pair() -> None:
             algorithm=_ALGORITHM,
         )
         jwt.decode(tok, get_jwt_public_key(), algorithms=[_ALGORITHM])
-    except JWTError as e:
+    except jwt.PyJWTError as e:
         raise RuntimeError(
             f"JWT 鍵ペアが不正です（秘密鍵と公開鍵が一致しないか、フォーマットが壊れています）: {e}"
         ) from e
@@ -86,7 +86,7 @@ def _decode_token(token: str) -> dict:
     """JWT をデコードしてペイロードを返す。失敗時は 401 を送出する。"""
     try:
         return jwt.decode(token, get_jwt_public_key(), algorithms=[_ALGORITHM])
-    except JWTError:
+    except jwt.PyJWTError:
         _raise_auth_failed("jwt_decode_error", with_bearer_header=True)
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ python-dotenv==1.2.2
 reportlab==5.0.0
 google-cloud-storage==3.12.0
 pytest==9.1.1
-python-jose[cryptography]==3.5.0
+PyJWT[crypto]==2.13.0
 httpx==0.28.1
 # マルチプロバイダ LLM（ADR-0013）。Gemini = google-genai、GPT = openai。
 # Gemini / Anthropic は Vertex AI（SA→ADC）経由（ADR-0015）。anthropic[vertex] の

--- a/backend/tests/auth/test_token_manager.py
+++ b/backend/tests/auth/test_token_manager.py
@@ -7,6 +7,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jwt
 import pytest
 from app.core.security.auth import (
     create_access_token,
@@ -14,7 +15,6 @@ from app.core.security.auth import (
 )
 from app.core.settings import get_cookie_samesite, get_cookie_secure
 from app.routers.auth.token_manager import GITHUB_OAUTH_STATE_COOKIE
-from jose import jwt
 
 from conftest import _test_public_key, auth_header
 


### PR DESCRIPTION
## 背景

`python-jose[cryptography]` の推移的依存 `ecdsa 0.19.2` に**修正版の出ない脆弱性** `PYSEC-2026-1325`（Minerva タイミング攻撃・P-256、CVSS 7.4）が存在し、CI の `pip-audit` が **全オープン PR・main 共通で fail** していた。メンテナが「サイドチャネルは対象外」として修正しない方針のため `requirements.txt` の「バージョン引き上げ」運用が使えない。

## 対応

DevForge の JWT は **RS256 のみ**（`app/core/security/auth.py`）で `python-jose` は cryptography バックエンドを使い、`ecdsa` 経路（`ecdsa.SigningKey.sign_digest()`）は**一切通らない**。そのため脆弱性は実質非該当だが、依存ツリーから消すのが最もクリーンと判断し `PyJWT[crypto]` へ移行して `ecdsa` 依存自体を除去する。

- `auth.py`: `jose.JWTError` → `jwt.PyJWTError`（RS256 の署名・検証挙動は不変）
- `requirements.txt`: `python-jose[cryptography]==3.5.0` → `PyJWT[crypto]==2.13.0`
- `THIRD_PARTY_LICENSES.md` を `make licenses` で再生成
- `README.md` / `.claude/rules/backend/auth-security.md` の JWT ライブラリ表記を更新

## 検証

- `pip-audit -r requirements.txt` → **No known vulnerabilities found**（ecdsa がツリーから消失）
- auth / security テスト 150 件 pass（HS256→RS256 拒否テスト含む）
- `make ci` full green

## 影響範囲

このマージ後、blocker が解消されるため滞留中の Renovate PR（#466 / #467 / #468 / #470）も緑化してマージ可能になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s authentication implementation to use a different JWT library, with no expected change to login or token behavior.
  * Refreshed related dependency and license listings to match the current setup.

* **Documentation**
  * Aligned the README and internal guidance with the updated authentication stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->