### PR TITLE
fix(web): スキル畳み込みバッジの文言を「N 件をまとめる」→「N 件内包」に変更

### DIFF
--- a/web/src/constants/messages.ts
+++ b/web/src/constants/messages.ts
@@ -235,8 +235,8 @@ export const SKILL_DISPLAY_MESSAGES = {
   EMPTY: "検出されたスキルがありません。先に GitHub 連携を実行してください。",
   /** 提案が 0 件だったときの表示。 */
   PROPOSE_EMPTY: "提案できる表示名がありませんでした。",
-  /** 畳み込みメンバー数のラベル接尾（例: 「3 件をまとめる」）。 */
-  memberCountLabel: (count: number): string => `${count} 件をまとめる`,
+  /** 畳み込みメンバー数のラベル接尾（例: 「3 件内包」）。 */
+  memberCountLabel: (count: number): string => `${count} 件内包`,
 } as const;
 
 /** 年セレクトの選択肢表記「N年」。 */


### PR DESCRIPTION
## 概要

検出スキルの畳み込みグループに表示されるメンバー数バッジの文言を、「**N 件をまとめる**」から「**N 件内包**」に変更する。

`SkillDisplaySection` のスキルチップで、複数スキルが1つの表示名グループに畳まれている場合に出る接尾ラベル（ADR-0016 D11）。

## 変更内容

- `web/src/constants/messages.ts` の `SKILL_DISPLAY_MESSAGES.memberCountLabel` を `${count} 件をまとめる` → `${count} 件内包` に変更
- docstring の例も追従

## 影響範囲

- 参照箇所は `SkillDisplaySection.tsx` の1箇所のみ。UI 文言のみの変更で、挙動・API・型契約に影響なし。
- `make ci` 通過済み（web 382 tests passed / build OK）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the member count label to use clearer, more concise wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->