### PR TITLE
fix(ci): js-yaml の advisory を audit allowlist に追加（GHSA-52cp-r559-cp3m）

### DIFF
--- a/web/scripts/audit-check.mjs
+++ b/web/scripts/audit-check.mjs
@@ -24,6 +24,15 @@ const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // 許容する advisory。GHSA ID をキーに、理由と見直し期限を残す。
 // 恒久対応 (vite 8 / Rolldown 移行) 完了時にエントリを削除すること。
 const ALLOWLIST = {
+  "GHSA-52cp-r559-cp3m": {
+    reason:
+      "js-yaml の YAML merge-key チェーンによる二次的 CPU 消費 (DoS)。" +
+      "openapi-typescript(dev 依存) → @redocly/openapi-core 経由の推移的依存で、" +
+      "自前 backend の OpenAPI スキーマ (信頼済み) を codegen する時だけ使用。" +
+      "本番バンドル非到達・攻撃者制御の YAML を parse しない。@redocly/openapi-core は" +
+      "全バージョンが脆弱な js-yaml に依存し npm audit fix でも解消不可のため時限的に許容。",
+    reviewBy: "2026-09-30 (openapi-typescript / @redocly の js-yaml>4.2.0 対応を待つ)",
+  },
   "GHSA-gv7w-rqvm-qjhr": {
     reason:
       "esbuild の Deno モジュール install-time RCE (NPM_CONFIG_REGISTRY 経由)。" +


### PR DESCRIPTION
## 概要

新規公開された **js-yaml の advisory（[GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m), high, YAML merge-key チェーンによる二次的 CPU 消費）** が `npm audit` ゲート（`web/scripts/audit-check.mjs`）で **全 web PR / main の CI を落とす**ようになった。既存の esbuild 2 件と同じ allowlist 機構で時限的に許容する。

> リポジトリ横断の CI 赤（依存起因）。blog 撤去（#519 / PR #530）とは無関係の pre-existing 問題を切り出したもの。#530 の CI を green にする前提として先にマージ推奨。

## 到達可能性の分析（allowlist の根拠）

- js-yaml は `openapi-typescript`（**devDependency**）→ `@redocly/openapi-core` 経由の**推移的依存**
- 用途は `make codegen-types` の**ビルド時 codegen のみ**。パース対象は**自前 backend の OpenAPI スキーマ（信頼済み）**で、攻撃者制御の YAML を parse しない
- **本番バンドル非到達**（openapi-typescript は CLI ツール、`web/src` からは未 import）
- `@redocly/openapi-core` は全バージョンが脆弱な js-yaml に依存し、**`npm audit fix` でも解消不可**（`--force` = openapi-typescript の破壊的更新が必要）

以上より、DevForge の使用形態では DoS の攻撃面に到達不能。恒久対応（上流の js-yaml>4.2.0 対応）まで allowlist で時限許容する。

## 変更

- `web/scripts/audit-check.mjs` の `ALLOWLIST` に `GHSA-52cp-r559-cp3m` を理由・見直し期限（2026-09-30）付きで追加

## 検証

- `node web/scripts/audit-check.mjs` → exit 0（「High/Critical の未許容 advisory はありません」）
- qs（moderate）は audit-check の対象外（high/critical のみブロック）のため影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)