### PR TITLE
フロントエンド URL を Cloudflare Pages の実 URL に修正し、Pages プロジェクト名から導出する

### DIFF
--- a/.claude/rules/common/review.md
+++ b/.claude/rules/common/review.md
@@ -45,6 +45,7 @@ PR 後の CodeRabbit 指摘対応・手動レビュー・`/code-review` の結�
 - ADR の新規作成・ステータス変更に対する `docs/adr/README.md` 索引の更新漏れ
 - **手順・フローを変えたら、それを記述している他の docs / rules も同じ差分で更新する**（RV 導入時に `rules/common/tdd.md` の「`make ci` → stage」と CLAUDE.md のモデル切り替えタイミングが drift した実例）
 - docs / rules に書いてある事実と差分の実装が矛盾していないか
+- **設定値を直したら、同じ値に言及している同一ファイル内の他の行も突合する**（手順書は表・チェックリスト・本文で同じ値を繰り返しがち。ENV_CHECKLIST の表だけ直して手順の行が古いままだった実例。PR #571 で CodeRabbit が検出）
 
 ### ルール違反
 

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -1,9 +1,13 @@
-project_id                     = "devforge-dev-20260311"
-app_name                       = "devforge"
-environment                    = "dev"
-template_version               = "v0.1.0"
-cors_origins                   = "https://devforge-dev-20260311.web.app,https://devforge-dev-20260311.firebaseapp.com"
-callback_base_url              = "https://devforge-dev-20260311.web.app"
+project_id       = "devforge-dev-20260311"
+app_name         = "devforge"
+environment      = "dev"
+template_version = "v0.1.0"
+# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
+# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
+# カスタムドメイン（app-dev.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
+# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
+cors_origins                   = "https://devforge-dev.pages.dev"
+callback_base_url              = "https://devforge-dev.pages.dev"
 cloudflare_pages_project_name  = "devforge-dev"
 cloudflare_subdomain           = "app-dev"
 cloudflare_production_branch   = "dev"

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -2,12 +2,8 @@ project_id       = "devforge-dev-20260311"
 app_name         = "devforge"
 environment      = "dev"
 template_version = "v0.1.0"
-# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
-# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
-# カスタムドメイン（app-dev.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
-# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
-cors_origins                   = "https://devforge-dev.pages.dev"
-callback_base_url              = "https://devforge-dev.pages.dev"
+# Cloud Run の CORS_ORIGINS / callback_base_url は、この Pages プロジェクト名から
+# shared/main.tf の local.frontend_url が導出する（https://<name>.pages.dev）。
 cloudflare_pages_project_name  = "devforge-dev"
 cloudflare_subdomain           = "app-dev"
 cloudflare_production_branch   = "dev"

--- a/infra/environments/prod/ENV_CHECKLIST.md
+++ b/infra/environments/prod/ENV_CHECKLIST.md
@@ -34,6 +34,6 @@
 - [ ] GitHub Secrets 登録
   - [ ] `GCP_SA_KEY_PROD`（prodデプロイ用サービスアカウントキーJSON）
   - [ ] `VITE_API_BASE_URL_PROD`（prod Cloud Run サービスURL）
-- [ ] Cloudflare Pages プロジェクト設定（`devforge` プロジェクト、prod ブランチを紐付け）
+- [ ] Cloudflare Pages プロジェクト設定（`devforge` プロジェクト、`main` ブランチを紐付け）
 - [ ] GitHub OAuth アプリ登録（prod用コールバックURL設定）
 - [ ] prod デプロイ前に stg での動作確認を完了させること

--- a/infra/environments/prod/ENV_CHECKLIST.md
+++ b/infra/environments/prod/ENV_CHECKLIST.md
@@ -11,7 +11,7 @@
 | GCS_BUCKET_NAME | DBバックアップ用GCSバケット名 | `devforge-prod-db` | Cloud Run env |
 | GCS_DB_OBJECT | GCS上のDBオブジェクトパス | 例: `devforge/prod/db.sqlite` | Cloud Run env |
 | ADMIN_TOKEN | `/admin/backup` エンドポイント認証トークン | ⚠️ 環境別に生成が必要 | Secret Manager |
-| CORS_ORIGINS | 許可するCORSオリジン | `https://devforge.pages.dev` | Cloud Run env |
+| CORS_ORIGINS | 許可するCORSオリジン | `https://devforge.pages.dev`（`cloudflare_pages_project_name` から自動導出） | Cloud Run env（tofu が設定） |
 | COOKIE_SECURE | Secure Cookie フラグ | `true` | Cloud Run env |
 | COOKIE_SAMESITE | SameSite Cookie 属性 | `none` | Cloud Run env |
 

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -2,12 +2,8 @@ project_id       = "devforge-prod-20260404"
 app_name         = "devforge"
 environment      = "prod"
 template_version = "v0.1.0"
-# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
-# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
-# カスタムドメイン（app.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
-# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
-cors_origins                   = "https://devforge.pages.dev"
-callback_base_url              = "https://devforge.pages.dev"
+# Cloud Run の CORS_ORIGINS / callback_base_url は、この Pages プロジェクト名から
+# shared/main.tf の local.frontend_url が導出する（https://<name>.pages.dev）。
 cloudflare_pages_project_name  = "devforge"
 cloudflare_subdomain           = "app"
 cloudflare_production_branch   = "main"

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -1,9 +1,13 @@
-project_id                     = "devforge-prod-20260404"
-app_name                       = "devforge"
-environment                    = "prod"
-template_version               = "v0.1.0"
-cors_origins                   = "https://devforge-prod.web.app,https://devforge-prod.firebaseapp.com"
-callback_base_url              = "https://devforge-prod.web.app"
+project_id       = "devforge-prod-20260404"
+app_name         = "devforge"
+environment      = "prod"
+template_version = "v0.1.0"
+# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
+# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
+# カスタムドメイン（app.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
+# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
+cors_origins                   = "https://devforge.pages.dev"
+callback_base_url              = "https://devforge.pages.dev"
 cloudflare_pages_project_name  = "devforge"
 cloudflare_subdomain           = "app"
 cloudflare_production_branch   = "main"

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -12,6 +12,23 @@ provider "turso" {
 }
 
 # --------------------------------------------------------------------
+# フロントエンドの配信 URL（CORS_ORIGINS / OAuth コールバックの導出元）
+#
+# 配信元は Cloudflare Pages（cloudflare_pages_project.app）。
+# cloudflare_use_custom_domain は全環境 false のため、実 URL は Pages の
+# デフォルトサブドメイン <cloudflare_pages_project_name>.pages.dev になる。
+# tfvars に URL をベタ書きすると Pages プロジェクト名との二重管理になり、
+# 改名時に CORS と OAuth コールバックが同時に壊れるため、ここで導出する。
+#
+# カスタムドメイン（app-dev.<zone> 等）へ移行する場合は、
+# cloudflare_use_custom_domain / cloudflare_zone_id の指定と併せて
+# この local を分岐させること（cloudflare_subdomain がホスト名側になる）。
+# --------------------------------------------------------------------
+locals {
+  frontend_url = "https://${var.cloudflare_pages_project_name}.pages.dev"
+}
+
+# --------------------------------------------------------------------
 # stack composition（全環境共通）
 # 各 module の呼び出しは ../../modules/devforge_stack に集約されている。
 # 環境差分は terraform.tfvars 経由（environment / Cloudflare Pages 設定 /
@@ -27,8 +44,8 @@ module "devforge_stack" {
   region                         = var.region
   deployer_service_account_email = var.deployer_service_account_email
 
-  cors_origins        = var.cors_origins
-  callback_base_url   = var.callback_base_url
+  cors_origins        = local.frontend_url
+  callback_base_url   = local.frontend_url
   enable_github_oauth = var.enable_github_oauth
 
   alert_email = var.alert_email

--- a/infra/environments/shared/variables.tf
+++ b/infra/environments/shared/variables.tf
@@ -35,16 +35,8 @@ variable "template_version" {
   type        = string
 }
 
-variable "cors_origins" {
-  description = "Allowed CORS origins for the API."
-  type        = string
-}
-
-variable "callback_base_url" {
-  description = "OAuth callback base URL."
-  type        = string
-  default     = ""
-}
+# cors_origins / callback_base_url は変数ではなく main.tf の local.frontend_url で
+# cloudflare_pages_project_name から導出する（tfvars との二重管理を避けるため）。
 
 variable "cloudflare_api_token" {
   description = "Cloudflare API token injected via TF_VAR_cloudflare_api_token."

--- a/infra/environments/stg/ENV_CHECKLIST.md
+++ b/infra/environments/stg/ENV_CHECKLIST.md
@@ -11,7 +11,7 @@
 | GCS_BUCKET_NAME | DBバックアップ用GCSバケット名 | `devforge-stg-db` | Cloud Run env |
 | GCS_DB_OBJECT | GCS上のDBオブジェクトパス | 例: `devforge/stg/db.sqlite` | Cloud Run env |
 | ADMIN_TOKEN | `/admin/backup` エンドポイント認証トークン | ⚠️ 環境別に生成が必要 | Secret Manager |
-| CORS_ORIGINS | 許可するCORSオリジン | `https://stg.devforge.pages.dev` | Cloud Run env |
+| CORS_ORIGINS | 許可するCORSオリジン | `https://devforge-stg.pages.dev`（`cloudflare_pages_project_name` から自動導出） | Cloud Run env（tofu が設定） |
 | COOKIE_SECURE | Secure Cookie フラグ | `true` | Cloud Run env |
 | COOKIE_SAMESITE | SameSite Cookie 属性 | `none` | Cloud Run env |
 

--- a/infra/environments/stg/ENV_CHECKLIST.md
+++ b/infra/environments/stg/ENV_CHECKLIST.md
@@ -34,5 +34,5 @@
 - [ ] GitHub Secrets 登録
   - [ ] `GCP_SA_KEY_STG`（stgデプロイ用サービスアカウントキーJSON）
   - [ ] `VITE_API_BASE_URL_STG`（stg Cloud Run サービスURL）
-- [ ] Cloudflare Pages プロジェクト設定（`devforge` プロジェクト、stg ブランチを紐付け）
+- [ ] Cloudflare Pages プロジェクト設定（`devforge-stg` プロジェクト、`stg` ブランチを紐付け）
 - [ ] GitHub OAuth アプリ登録（stg用コールバックURL設定）

--- a/infra/environments/stg/terraform.tfvars
+++ b/infra/environments/stg/terraform.tfvars
@@ -2,12 +2,8 @@ project_id       = "devforge-stg-20260404"
 app_name         = "devforge"
 environment      = "stg"
 template_version = "v0.1.0"
-# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
-# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
-# カスタムドメイン（app-stg.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
-# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
-cors_origins                   = "https://devforge-stg.pages.dev"
-callback_base_url              = "https://devforge-stg.pages.dev"
+# Cloud Run の CORS_ORIGINS / callback_base_url は、この Pages プロジェクト名から
+# shared/main.tf の local.frontend_url が導出する（https://<name>.pages.dev）。
 cloudflare_pages_project_name  = "devforge-stg"
 cloudflare_subdomain           = "app-stg"
 cloudflare_production_branch   = "stg"

--- a/infra/environments/stg/terraform.tfvars
+++ b/infra/environments/stg/terraform.tfvars
@@ -1,9 +1,13 @@
-project_id                     = "devforge-stg-20260404"
-app_name                       = "devforge"
-environment                    = "stg"
-template_version               = "v0.1.0"
-cors_origins                   = "https://devforge-stg.web.app,https://devforge-stg.firebaseapp.com"
-callback_base_url              = "https://devforge-stg.web.app"
+project_id       = "devforge-stg-20260404"
+app_name         = "devforge"
+environment      = "stg"
+template_version = "v0.1.0"
+# フロントの配信元は Cloudflare Pages（cloudflare_pages_project.app）。use_custom_domain は
+# 未指定＝false のため、実 URL は <cloudflare_pages_project_name>.pages.dev になる。
+# カスタムドメイン（app-stg.<zone>）へ移行する場合は use_custom_domain / cloudflare_zone_id と
+# 併せてここも変更すること（この 2 値は Cloud Run の CORS_ORIGINS / callback_base_url に入る）。
+cors_origins                   = "https://devforge-stg.pages.dev"
+callback_base_url              = "https://devforge-stg.pages.dev"
 cloudflare_pages_project_name  = "devforge-stg"
 cloudflare_subdomain           = "app-stg"
 cloudflare_production_branch   = "stg"


### PR DESCRIPTION
## 概要

`infra/environments/*/terraform.tfvars` の `cors_origins` / `callback_base_url` に **Firebase Hosting 時代の URL**（`*.web.app` / `*.firebaseapp.com`）が残っていた。フロントの配信元はすでに Cloudflare Pages なので、実 URL に修正する。

さらに、修正後も URL が `cloudflare_pages_project_name` と同じ tfvars 内で二重管理になっていたため、**Pages プロジェクト名から導出する形に変更**した。

## 変更内容

### 1. 実 URL への修正（`c4126b1`）

| 環境 | 修正前 | 修正後 |
|---|---|---|
| dev | `devforge-dev-20260311.web.app` ほか | `devforge-dev.pages.dev` |
| stg | `devforge-stg.web.app` ほか | `devforge-stg.pages.dev` |
| prod | `devforge-prod.web.app` ほか | `devforge.pages.dev` |

この 2 値は Cloud Run の `CORS_ORIGINS` / `CALLBACK_BASE_URL` に入るため、ズレていると CORS と GitHub OAuth コールバックが同時に壊れる。

### 2. Pages プロジェクト名からの導出（`9a374b4`）

URL をベタ書きしたままだと、Pages プロジェクト名を変えたときに URL 側の更新漏れで同じ事故が再発する。`shared/main.tf` で導出する形に変えた。

```hcl
locals {
  frontend_url = "https://${var.cloudflare_pages_project_name}.pages.dev"
}
```

- `shared/variables.tf` から `cors_origins` / `callback_base_url` の変数定義を削除
- 各 `terraform.tfvars` から URL 2 行を削除（従来の 4 行コメントも 2 行に圧縮）
- `main.tf` / `variables.tf` は `shared/` への symlink のため、1 ファイルの修正で 3 環境に反映される
- 外部モジュールへの依存は増やしていない（`cloudflare` モジュールの `pages_subdomain` 出力を配線する案は不採用）

### 3. ENV_CHECKLIST の追従

- **stg**: `CORS_ORIGINS` の推奨値が `https://stg.devforge.pages.dev` になっていた。Pages の命名規則 `<project>.pages.dev` に合わず、実在しないホスト。実値 `https://devforge-stg.pages.dev` に修正
- **stg / prod**: 導出値になったため「`cloudflare_pages_project_name` から自動導出」「Cloud Run env（tofu が設定）」と明記し、手動設定値と誤読させないようにした

## 検証

- `make infra-fmt-check`: pass
- `make infra-validate`（dev / stg / prod）: 3 環境とも `Success! The configuration is valid.`
- `make ci`: pass
- **導出値が変更前と一致**することを確認: dev `https://devforge-dev.pages.dev` / stg `https://devforge-stg.pages.dev` / prod `https://devforge.pages.dev`
- `var.cors_origins` / `var.callback_base_url` の残存参照ゼロ。`TF_VAR_cors_origins` / `TF_VAR_callback_base_url` での注入もワークフロー・シェルスクリプトに無く、変数削除で壊れる経路がないことを確認
- Firebase 系 URL（`*.web.app` / `*.firebaseapp.com`）をリポジトリ全体から検索し、残存ゼロを確認

## 注意点

- **`tofu plan` は未実行**（state 認証が要るため）。導出値が変更前と同一になることはコード上で確認済みで Cloud Run env に差分は出ない想定だが、**apply 前に plan で差分ゼロを確認してほしい**
- **変数削除は破壊的変更**: `cors_origins` / `callback_base_url` を `shared/variables.tf` から削除した。CI・スクリプトからの `TF_VAR_*` 注入が無いことは確認済みだが、手元で環境変数経由の指定をしている場合は効かなくなる
- カスタムドメイン（`app-dev.<zone>` 等）へ移行する場合は、`cloudflare_use_custom_domain` / `cloudflare_zone_id` の指定と併せて `local.frontend_url` を分岐させる必要がある（手順は `shared/main.tf` のコメントに記載）。現状は 3 環境とも `false` で挙動は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cloud Run CORS and OAuth callback URLs are now automatically derived from the Cloudflare Pages project name across development, staging, and production environments.
  * Removed the need to maintain separate URL settings, reducing configuration drift and simplifying environment setup.

* **Documentation**
  * Updated environment checklists and configuration guidance to reflect the automatically generated frontend URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->