### PR TITLE
[ドラフト縮小 1/7] リポジトリ選定シグナルを AnalyzedRepoSummary へ永続化

### DIFF
--- a/backend/app/schemas/github_link.py
+++ b/backend/app/schemas/github_link.py
@@ -35,16 +35,42 @@ class ContributionCalendar(BaseModel):
 
 
 class AnalyzedRepoSummary(BaseModel):
-    """連携で分析したリポジトリ 1 件分のサマリ（ADR-0018）。
+    """連携で分析したリポジトリ 1 件分のサマリ（ADR-0018・0026）。
 
     経歴書ドラフト生成のルールベースマッピングが入力にする決定論データ。
     スキル証跡（github_skill_evidence）と同一連携実行時点のスナップショットになる。
+
+    ADR-0026 決定 4 で選定シグナル（topics 以下）を追加した。いずれも収集層の
+    ``RepoData`` が連携実行時に取得済みの値で、**GitHub API の追加呼び出しはしない**。
+    旧形式キャッシュ（当該キーを持たない）でもパースできるよう既定値を持たせるが、
+    シグナル無しでの選定は品質が担保できないため、``resume_draft/context.py`` が
+    キーの有無を見て 409（再連携導線）へ倒す。
     """
 
     full_name: str = Field(description="owner/name 形式のリポジトリ名")
     description: str = Field(default="", description="GitHub のリポジトリ説明（無ければ空文字）")
     created_at: str = Field(default="", description="ISO 8601 形式の作成日時")
     pushed_at: str = Field(default="", description="ISO 8601 形式の最終 push 日時")
+    topics: List[str] = Field(
+        default_factory=list,
+        description="GitHub の topics。学習用途（tutorial / practice 等）の判定に使う",
+    )
+    language_bytes_total: int = Field(
+        default=0,
+        description="全言語のバイト数合計。実装量の代理指標",
+    )
+    direct_dependency_count: int = Field(
+        default=0,
+        description="manifest が直接宣言する依存の数（dev / indirect を除く）。依存の厚み",
+    )
+    ecosystem_count: int = Field(
+        default=0,
+        description="依存を宣言しているエコシステム数（npm / pypi / go / cargo）",
+    )
+    has_infra: bool = Field(
+        default=False,
+        description="IaC（Terraform 等）の宣言があるか",
+    )
 
 
 class GitHubLinkResponse(BaseModel):

--- a/backend/app/services/agent/resume_draft/context.py
+++ b/backend/app/services/agent/resume_draft/context.py
@@ -40,10 +40,19 @@ _KIND_TO_CATEGORY: dict[str, str] = {
 # 言えないため経歴書には載せない
 _PACKAGE_SIGNAL_ACTUAL_IMPORT = "actual_import"
 
-# ADR-0026 決定 4 で追加した選定シグナルの代表キー。スキーマ上は既定値を持つ
-# Optional なのでパースは通ってしまうが、シグナル無しの選定は品質を担保できない。
-# 生 JSON のキー有無で旧形式を判別し、"repos" 欠落と同じ 409 導線へ倒す。
-_SELECTION_SIGNAL_KEY = "language_bytes_total"
+# ADR-0026 決定 4 で追加した選定シグナル。スキーマ上は既定値を持つ Optional なので
+# パースは通ってしまうが、シグナル欠落のまま選定すると品質を担保できない。生 JSON の
+# キー有無で旧形式を判別し、"repos" 欠落と同じ 409 導線へ倒す。
+# 代表キー 1 つでは「一部だけ持つキャッシュ」を見逃すため、全キーの存在を要求する。
+_SELECTION_SIGNAL_KEYS = frozenset(
+    {
+        "topics",
+        "language_bytes_total",
+        "direct_dependency_count",
+        "ecosystem_count",
+        "has_infra",
+    }
+)
 
 
 class ResumeDraftSourceUnavailableError(Exception):
@@ -106,7 +115,7 @@ def build_draft_source(db: Session, user: User) -> DraftSource:
     # ADR-0026 決定 4 より前のキャッシュは選定シグナルを持たない。Pydantic は既定値で
     # 通してしまうため、ここも生 JSON のキー有無で判別して再連携を促す。
     if any(
-        isinstance(raw, dict) and _SELECTION_SIGNAL_KEY not in raw
+        isinstance(raw, dict) and not _SELECTION_SIGNAL_KEYS.issubset(raw)
         for raw in cache.result["repos"] or []
     ):
         raise ResumeDraftSourceUnavailableError(

--- a/backend/app/services/agent/resume_draft/context.py
+++ b/backend/app/services/agent/resume_draft/context.py
@@ -20,6 +20,7 @@ from ....repositories.github_link import GitHubLinkCacheRepository
 from ....repositories.skill import GitHubSkillRepository
 from ....schemas.github_link import AnalyzedRepoSummary, GitHubLinkResponse
 from ...intelligence.skills.types import (
+    DEPENDENCY_KIND_DIRECT,
     SKILL_KIND_INFRA,
     SKILL_KIND_LANGUAGE,
     SKILL_KIND_PACKAGE,
@@ -37,8 +38,12 @@ _KIND_TO_CATEGORY: dict[str, str] = {
 # package スキルを技術スタックに採用する根拠の下限。manifest の間接依存
 # （dependency_kind が direct 以外かつ実 import 未確認）は「使った技術」とは
 # 言えないため経歴書には載せない
-_PACKAGE_DEPENDENCY_KIND_DIRECT = "direct"
 _PACKAGE_SIGNAL_ACTUAL_IMPORT = "actual_import"
+
+# ADR-0026 決定 4 で追加した選定シグナルの代表キー。スキーマ上は既定値を持つ
+# Optional なのでパースは通ってしまうが、シグナル無しの選定は品質を担保できない。
+# 生 JSON のキー有無で旧形式を判別し、"repos" 欠落と同じ 409 導線へ倒す。
+_SELECTION_SIGNAL_KEY = "language_bytes_total"
 
 
 class ResumeDraftSourceUnavailableError(Exception):
@@ -98,6 +103,15 @@ def build_draft_source(db: Session, user: User) -> DraftSource:
         raise ResumeDraftSourceUnavailableError(
             "連携キャッシュにリポジトリサマリがありません（旧形式）"
         )
+    # ADR-0026 決定 4 より前のキャッシュは選定シグナルを持たない。Pydantic は既定値で
+    # 通してしまうため、ここも生 JSON のキー有無で判別して再連携を促す。
+    if any(
+        isinstance(raw, dict) and _SELECTION_SIGNAL_KEY not in raw
+        for raw in cache.result["repos"] or []
+    ):
+        raise ResumeDraftSourceUnavailableError(
+            "連携キャッシュに選定シグナルがありません（旧形式）"
+        )
     try:
         result = GitHubLinkResponse.model_validate(cache.result)
     except ValidationError:
@@ -134,7 +148,7 @@ def _invert_skill_evidence(db: Session, user_id: str) -> dict[str, list[RepoTech
         name = skill.display_name or skill.canonical_name
         for evidence in skill.evidence:
             if skill.kind == SKILL_KIND_PACKAGE and not (
-                evidence.dependency_kind == _PACKAGE_DEPENDENCY_KIND_DIRECT
+                evidence.dependency_kind == DEPENDENCY_KIND_DIRECT
                 or evidence.signal_source == _PACKAGE_SIGNAL_ACTUAL_IMPORT
             ):
                 continue

--- a/backend/app/services/intelligence/response_mapper.py
+++ b/backend/app/services/intelligence/response_mapper.py
@@ -3,6 +3,31 @@ from typing import List
 from ...schemas.github_link import AnalyzedRepoSummary, GitHubLinkResponse
 from .github_collector import RepoData
 from .pipeline import IntelligenceResult
+from .skills.types import DEPENDENCY_KIND_DIRECT
+
+
+def _to_repo_summary(repo: RepoData) -> AnalyzedRepoSummary:
+    """収集層の RepoData を永続化用サマリへ写す（ADR-0026 決定 4）。
+
+    シグナルはすべて連携実行時に取得済みの値から算出する。GitHub API は叩かない。
+    """
+    return AnalyzedRepoSummary(
+        full_name=f"{repo.owner}/{repo.name}",
+        description=repo.description,
+        created_at=repo.created_at,
+        pushed_at=repo.pushed_at,
+        topics=list(repo.topics),
+        language_bytes_total=sum(repo.languages.values()),
+        # dev / indirect / peer / build は開発補助・推移的依存であり、リポジトリの
+        # 実装内容を表さないため厚みに数えない（ADR-0026 決定 4）
+        direct_dependency_count=sum(
+            1
+            for decl in repo.package_declarations
+            if decl.dependency_kind == DEPENDENCY_KIND_DIRECT
+        ),
+        ecosystem_count=len({decl.ecosystem for decl in repo.package_declarations}),
+        has_infra=bool(repo.infra_declarations),
+    )
 
 
 def map_pipeline_result(
@@ -14,15 +39,7 @@ def map_pipeline_result(
     repos を渡すと、経歴書ドラフト生成（ADR-0018）の入力になるリポジトリ単位の
     サマリを ``repos`` フィールドに詰めて永続化対象へ含める。
     """
-    repo_summaries = [
-        AnalyzedRepoSummary(
-            full_name=f"{repo.owner}/{repo.name}",
-            description=repo.description,
-            created_at=repo.created_at,
-            pushed_at=repo.pushed_at,
-        )
-        for repo in (repos or [])
-    ]
+    repo_summaries = [_to_repo_summary(repo) for repo in (repos or [])]
     return GitHubLinkResponse(
         username=result.username,
         repos_analyzed=result.repos_analyzed,

--- a/backend/app/services/intelligence/skills/types.py
+++ b/backend/app/services/intelligence/skills/types.py
@@ -14,6 +14,10 @@ from dataclasses import dataclass
 #   build   : build-system 依存（pyproject build-system.requires 等）
 DEPENDENCY_KINDS = ("direct", "dev", "indirect", "peer", "build")
 
+# 「本番で直接使うと決めた依存」。実績スキルの採用基準（aggregator）と、リポジトリの
+# 依存の厚み（ADR-0026 決定 4 の選定シグナル）が同じ意味で参照するため定数化する。
+DEPENDENCY_KIND_DIRECT = "direct"
+
 # Layer 1 スキルの種別（D2）。
 SKILL_KIND_LANGUAGE = "language"
 SKILL_KIND_PACKAGE = "package"

--- a/backend/tests/test_github_link.py
+++ b/backend/tests/test_github_link.py
@@ -11,6 +11,10 @@ from app.services.intelligence.pipeline import (
 )
 from app.services.intelligence.response_mapper import map_pipeline_result
 from app.services.intelligence.skills import DetectedSkill
+from app.services.intelligence.skills.types import (
+    InfraResourceDeclaration,
+    PackageDeclaration,
+)
 
 from conftest import auth_header
 
@@ -36,6 +40,17 @@ def _make_repo(
         fork=False,
         stargazers_count=0,
         default_branch="main",
+    )
+
+
+def _intelligence_result() -> IntelligenceResult:
+    """map_pipeline_result に渡す最小の集計結果。"""
+    return IntelligenceResult(
+        username="testuser",
+        repos_analyzed=1,
+        unique_skills=1,
+        analyzed_at="2026-06-01T00:00:00",
+        languages={},
     )
 
 
@@ -83,6 +98,46 @@ def test_map_pipeline_result_includes_languages() -> None:
     # 撤去したフィールドはレスポンス schema に存在しない
     assert not hasattr(response, "detected_frameworks")
     assert response.contribution_calendars == []
+
+
+def test_map_pipeline_result_carries_selection_signals() -> None:
+    """RepoData の選定シグナルが AnalyzedRepoSummary へ写ること（ADR-0026 決定 4）。"""
+    repo = _make_repo(
+        name="app",
+        languages={"Python": 8000, "HCL": 2000},
+        topics=["fastapi", "tutorial"],
+    )
+    repo.package_declarations = [
+        PackageDeclaration(ecosystem="pypi", name="fastapi", dependency_kind="direct"),
+        PackageDeclaration(ecosystem="pypi", name="pytest", dependency_kind="dev"),
+        PackageDeclaration(ecosystem="npm", name="react", dependency_kind="direct"),
+    ]
+    repo.infra_declarations = [
+        InfraResourceDeclaration(tool="terraform", provider="google", resource_type="google_cloud_run_service")
+    ]
+
+    summary = map_pipeline_result(_intelligence_result(), repos=[repo]).repos[0]
+
+    assert summary.full_name == "testuser/app"
+    assert summary.topics == ["fastapi", "tutorial"]
+    assert summary.language_bytes_total == 10000
+    # dev 依存は厚みに数えない（direct のみ）
+    assert summary.direct_dependency_count == 2
+    assert summary.ecosystem_count == 2
+    assert summary.has_infra is True
+
+
+def test_map_pipeline_result_defaults_signals_without_declarations() -> None:
+    """宣言が無いリポジトリはシグナルが 0 / False になること。"""
+    summary = map_pipeline_result(
+        _intelligence_result(), repos=[_make_repo(name="empty", languages={}, topics=[])]
+    ).repos[0]
+
+    assert summary.topics == []
+    assert summary.language_bytes_total == 0
+    assert summary.direct_dependency_count == 0
+    assert summary.ecosystem_count == 0
+    assert summary.has_infra is False
 
 
 # ── aggregate_intelligence Tests（ADR-0016: 新基盤の検出スキルから集計）──────

--- a/backend/tests/test_resume_draft_api.py
+++ b/backend/tests/test_resume_draft_api.py
@@ -39,6 +39,12 @@ def _seed_link_data(db, username: str = "testuser", *, legacy: bool = False) -> 
                 "description": "タスク管理アプリ",
                 "created_at": "2024-01-01T00:00:00Z",
                 "pushed_at": "2026-06-01T00:00:00Z",
+                # ADR-0026 決定 4 の選定シグナル。欠けると旧形式扱いで 409 になる
+                "topics": ["python"],
+                "language_bytes_total": 1000,
+                "direct_dependency_count": 2,
+                "ecosystem_count": 1,
+                "has_infra": False,
             }
         ]
         skill = GitHubSkill(user_id=user.id, kind="language", canonical_name="Python")

--- a/backend/tests/test_resume_draft_mapper.py
+++ b/backend/tests/test_resume_draft_mapper.py
@@ -13,6 +13,7 @@ from app.models.skill import GitHubSkill, GitHubSkillEvidence
 from app.schemas.github_link import AnalyzedRepoSummary
 from app.schemas.resume import TechnologyStackItem
 from app.services.agent.resume_draft.context import (
+    _SELECTION_SIGNAL_KEYS,
     DraftSource,
     RepoTechnology,
     ResumeDraftNoRepositoriesError,
@@ -285,8 +286,7 @@ def test_build_draft_source_rejects_cache_without_selection_signals(db_session) 
     """
     user = _create_user(db_session)
     legacy = _repo_summary()
-    for key in ("topics", "language_bytes_total", "direct_dependency_count",
-                "ecosystem_count", "has_infra"):
+    for key in _SELECTION_SIGNAL_KEYS:
         del legacy[key]
     # スキーマは旧形式 JSON を既定値で受理する（後方互換）
     assert AnalyzedRepoSummary.model_validate(legacy).language_bytes_total == 0
@@ -299,6 +299,24 @@ def test_build_draft_source_rejects_cache_without_selection_signals(db_session) 
     with pytest.raises(ResumeDraftSourceUnavailableError) as exc:
         build_draft_source(db_session, user)
     assert not isinstance(exc.value, ResumeDraftNoRepositoriesError)
+
+
+@pytest.mark.parametrize("missing_key", sorted(_SELECTION_SIGNAL_KEYS))
+def test_build_draft_source_rejects_cache_missing_any_signal(db_session, missing_key) -> None:
+    """シグナルが 1 つでも欠けたキャッシュは旧形式として扱う。
+
+    代表キーだけを見ると「一部のシグナルだけ持つキャッシュ」を取りこぼし、
+    Pydantic の既定値で欠落を埋めたまま選定が走ってしまう。
+    """
+    user = _create_user(db_session)
+    partial = _repo_summary()
+    del partial[missing_key]
+    db_session.add(
+        GitHubLinkCache(user_id=user.id, status="completed", result=_cache_result(repos=[partial]))
+    )
+    db_session.commit()
+    with pytest.raises(ResumeDraftSourceUnavailableError):
+        build_draft_source(db_session, user)
 
 
 def test_build_draft_source_rejects_cache_with_partially_migrated_repos(db_session) -> None:

--- a/backend/tests/test_resume_draft_mapper.py
+++ b/backend/tests/test_resume_draft_mapper.py
@@ -213,6 +213,27 @@ def _cache_result(repos: list[dict] | None) -> dict:
     return result
 
 
+def _repo_summary(**overrides) -> dict:
+    """新形式（ADR-0026 決定 4）のリポジトリサマリ JSON を生成する。
+
+    選定シグナル（topics 以下）を含む。旧形式を再現したいテストは
+    ``_repo_summary()`` から当該キーを del して使う。
+    """
+    summary = {
+        "full_name": "octocat/app",
+        "description": "アプリ",
+        "created_at": "2024-01-01T00:00:00Z",
+        "pushed_at": "2026-06-01T00:00:00Z",
+        "topics": ["fastapi"],
+        "language_bytes_total": 12000,
+        "direct_dependency_count": 3,
+        "ecosystem_count": 1,
+        "has_infra": True,
+    }
+    summary.update(overrides)
+    return summary
+
+
 def _add_skill(db_session, user_id: str, *, kind: str, name: str, evidence: list[dict]) -> None:
     """スキル + 証跡を直接投入する。"""
     skill = GitHubSkill(user_id=user_id, kind=kind, canonical_name=name)
@@ -256,15 +277,71 @@ def test_build_draft_source_rejects_empty_repos_as_no_repositories(db_session) -
         build_draft_source(db_session, user)
 
 
+def test_build_draft_source_rejects_cache_without_selection_signals(db_session) -> None:
+    """ADR-0026 より前のキャッシュ（選定シグナル無し）は再連携が必要。
+
+    スキーマ側は既定値を持つのでパース自体は通ってしまう。生 JSON のキー有無で
+    判別して 409 導線に倒していることを確認する。
+    """
+    user = _create_user(db_session)
+    legacy = _repo_summary()
+    for key in ("topics", "language_bytes_total", "direct_dependency_count",
+                "ecosystem_count", "has_infra"):
+        del legacy[key]
+    # スキーマは旧形式 JSON を既定値で受理する（後方互換）
+    assert AnalyzedRepoSummary.model_validate(legacy).language_bytes_total == 0
+
+    db_session.add(
+        GitHubLinkCache(user_id=user.id, status="completed", result=_cache_result(repos=[legacy]))
+    )
+    db_session.commit()
+    # NoRepositories ではなく「再連携で回復する」側の例外になること
+    with pytest.raises(ResumeDraftSourceUnavailableError) as exc:
+        build_draft_source(db_session, user)
+    assert not isinstance(exc.value, ResumeDraftNoRepositoriesError)
+
+
+def test_build_draft_source_rejects_cache_with_partially_migrated_repos(db_session) -> None:
+    """1 件でもシグナル無しが混ざれば旧形式として扱う（選定が偏るのを防ぐ）。"""
+    user = _create_user(db_session)
+    legacy = _repo_summary(full_name="octocat/legacy")
+    del legacy["language_bytes_total"]
+    db_session.add(
+        GitHubLinkCache(
+            user_id=user.id,
+            status="completed",
+            result=_cache_result(repos=[_repo_summary(), legacy]),
+        )
+    )
+    db_session.commit()
+    with pytest.raises(ResumeDraftSourceUnavailableError):
+        build_draft_source(db_session, user)
+
+
+def test_build_draft_source_keeps_selection_signals(db_session) -> None:
+    """新形式のシグナルが DraftSource までそのまま渡ること（#562 / #564 の入力）。"""
+    user = _create_user(db_session)
+    db_session.add(
+        GitHubLinkCache(
+            user_id=user.id,
+            status="completed",
+            result=_cache_result(repos=[_repo_summary()]),
+        )
+    )
+    db_session.commit()
+
+    repo = build_draft_source(db_session, user).repos[0]
+    assert repo.topics == ["fastapi"]
+    assert repo.language_bytes_total == 12000
+    assert repo.direct_dependency_count == 3
+    assert repo.ecosystem_count == 1
+    assert repo.has_infra is True
+
+
 def test_build_draft_source_inverts_skill_evidence(db_session) -> None:
     """スキル証跡が「リポ → 技術」に反転され、採用基準どおりフィルタされる。"""
     user = _create_user(db_session)
-    repo_summary = {
-        "full_name": "octocat/app",
-        "description": "アプリ",
-        "created_at": "2024-01-01T00:00:00Z",
-        "pushed_at": "2026-06-01T00:00:00Z",
-    }
+    repo_summary = _repo_summary()
     db_session.add(
         GitHubLinkCache(
             user_id=user.id, status="completed", result=_cache_result(repos=[repo_summary])

--- a/backend/tests/test_worker/test_resume_draft.py
+++ b/backend/tests/test_worker/test_resume_draft.py
@@ -69,6 +69,12 @@ def _seed(db: Session, username: str = "draft-user", *, repos: bool = True):
                     "description": "タスク管理アプリ",
                     "created_at": "2024-01-01T00:00:00Z",
                     "pushed_at": "2026-06-01T00:00:00Z",
+                    # ADR-0026 決定 4 の選定シグナル。欠けると旧形式扱いで 409 になる
+                    "topics": ["python"],
+                    "language_bytes_total": 1000,
+                    "direct_dependency_count": 2,
+                    "ecosystem_count": 1,
+                    "has_infra": False,
                 }
             ]
             if repos

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -949,10 +949,16 @@ export interface components {
         };
         /**
          * AnalyzedRepoSummary
-         * @description 連携で分析したリポジトリ 1 件分のサマリ（ADR-0018）。
+         * @description 連携で分析したリポジトリ 1 件分のサマリ（ADR-0018・0026）。
          *
          *     経歴書ドラフト生成のルールベースマッピングが入力にする決定論データ。
          *     スキル証跡（github_skill_evidence）と同一連携実行時点のスナップショットになる。
+         *
+         *     ADR-0026 決定 4 で選定シグナル（topics 以下）を追加した。いずれも収集層の
+         *     ``RepoData`` が連携実行時に取得済みの値で、**GitHub API の追加呼び出しはしない**。
+         *     旧形式キャッシュ（当該キーを持たない）でもパースできるよう既定値を持たせるが、
+         *     シグナル無しでの選定は品質が担保できないため、``resume_draft/context.py`` が
+         *     キーの有無を見て 409（再連携導線）へ倒す。
          */
         AnalyzedRepoSummary: {
             /**
@@ -968,16 +974,45 @@ export interface components {
              */
             description: string;
             /**
+             * Direct Dependency Count
+             * @description manifest が直接宣言する依存の数（dev / indirect を除く）。依存の厚み
+             * @default 0
+             */
+            direct_dependency_count: number;
+            /**
+             * Ecosystem Count
+             * @description 依存を宣言しているエコシステム数（npm / pypi / go / cargo）
+             * @default 0
+             */
+            ecosystem_count: number;
+            /**
              * Full Name
              * @description owner/name 形式のリポジトリ名
              */
             full_name: string;
+            /**
+             * Has Infra
+             * @description IaC（Terraform 等）の宣言があるか
+             * @default false
+             */
+            has_infra: boolean;
+            /**
+             * Language Bytes Total
+             * @description 全言語のバイト数合計。実装量の代理指標
+             * @default 0
+             */
+            language_bytes_total: number;
             /**
              * Pushed At
              * @description ISO 8601 形式の最終 push 日時
              * @default
              */
             pushed_at: string;
+            /**
+             * Topics
+             * @description GitHub の topics。学習用途（tutorial / practice 等）の判定に使う
+             */
+            topics?: string[];
         };
         /** Body_import_resume_pdf_api_agent_resume_import_pdf_post */
         Body_import_resume_pdf_api_agent_resume_import_pdf_post: {


### PR DESCRIPTION
Closes #561

## 概要

ADR-0026 決定 4。収集層の `RepoData` は topics / `package_declarations` / `infra_declarations` を保持しているのに、キャッシュへ永続化される `AnalyzedRepoSummary` は **full_name / description / created_at / pushed_at の 4 フィールドだけ**だった。判別材料を永続化層で捨てているため、ドラフトの選定ロジックは最終 push 日時と言語バイト数しか使えず、チュートリアルと実プロジェクトを区別できない。

本 PR は永続化層へ経路を通すところまで。選定ロジック自体の変更は #562 が担当する。

## 変更内容

### 1. 選定シグナルの追加（後方互換）

| フィールド | 型 | 算出元 |
|---|---|---|
| `topics` | `list[str]` | `RepoData.topics` |
| `language_bytes_total` | `int` | `languages` の合計 |
| `direct_dependency_count` | `int` | `package_declarations` のうち `direct` のみ |
| `ecosystem_count` | `int` | `package_declarations` のエコシステム種別数 |
| `has_infra` | `bool` | `infra_declarations` の有無 |

いずれも既定値を持つため、旧形式 JSON のパースは従来どおり通る。

**GitHub API の追加呼び出しはしない** — すべて連携実行時に `RepoData` が取得済みの値で、`_to_repo_summary` は既存フィールドを参照するだけ。collector には触れていない。

### 2. 旧形式キャッシュの判定（409 + 再連携導線）

スキーマ側は既定値で受理するが、シグナル無しでの選定は品質を担保できないため、`build_draft_source` が**生 JSON のキー有無**で判別して 409 へ倒す。ADR-0018 が定めた「`repos` キー欠落」判定と同じ流儀（Pydantic 検証後は既定値と区別できないため生 JSON を見る）。

**1 件でもシグナル無しが混ざれば旧形式扱い**にしている。部分的に許容すると、選定が「移行済みリポジトリだけ」に偏って本命を取りこぼすため。

`ResumeDraftNoRepositoriesError`（再連携では回復しない別導線）と取り違えていないことをテストで assert している。

### 3. 依存種別 `"direct"` の SSoT 化

`response_mapper` に定数を足すと同じ意味の比較が 4 箇所目になり、Rule of Three（`.claude/rules/common/duplication.md`）を超過するため、概念の定義元である `skills/types.py` に `DEPENDENCY_KIND_DIRECT` を置いて本差分の 2 箇所を移行した。

`github_collector.py:165` / `skills/aggregator.py:217` に残る 2 箇所は**差分範囲外のため本 PR では変更しない**（特に `aggregator.py` は mutmut スコープで TDD 手順が要る）。#562 以降で当該ファイルを触る回に併せる。

## テスト

新規 5 件:

- シグナルが `RepoData` → `AnalyzedRepoSummary` へ写ること（dev 依存を厚みに数えないことを含む）
- 宣言が無いリポジトリで既定値になること
- 旧形式（新キー無し）が**パースは通る**が 409 になること
- 部分移行（1 件だけ旧形式）でも 409 になること
- シグナルが `DraftSource` まで伝播すること（#562 / #564 の入力）

契約変更に伴い、旧形式 fixture を持つ既存テスト 3 ファイル（`test_resume_draft_mapper` / `test_resume_draft_api` / `test_worker/test_resume_draft`）を新形式へ更新した。旧契約を固定化したテストは残していない。

## 検証

- `make ci`: pass
- `make codegen-types` 実行済み。`web/src/api/generated.ts` の差分を同 PR に含む（ADR-0007）

## 注意点

- **既存ユーザーへの影響**: ADR-0026 より前の連携キャッシュを持つユーザーは、ドラフト生成前に**再連携が必要**になる。ADR-0026 決定 4 の明示的な決定どおりだが、既存ユーザー全員に効く
- **選定ロジックは変えていない**。`select_repos` は従来どおり最終 push 日時が第 1 キーのまま（#562 で変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repository summaries now include topics, language usage, direct dependency counts, ecosystem counts, and infrastructure indicators.
  - These signals are carried through analysis results to support more informative repository selection and draft generation.

- **Bug Fixes**
  - Incomplete or outdated cached repository data is now detected and handled gracefully instead of producing unreliable draft results.

- **Documentation**
  - Updated API documentation to describe the new repository metadata, legacy cache compatibility, and relevant error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->