### PR TITLE
[ドラフト縮小 2/7] ドラフトの選定順を「継続期間 × 実装量」へ変更しノイズ判定を付与

### DIFF
--- a/backend/app/services/agent/resume_draft/mapper.py
+++ b/backend/app/services/agent/resume_draft/mapper.py
@@ -9,6 +9,7 @@ DB・LLM・時刻に依存しない（``today`` は引数で受ける）。捏�
 （担当工程・チーム規模の水増し等）はここでは生成しない。
 """
 
+from dataclasses import dataclass
 from datetime import date
 
 from .context import DraftSource, RepoTechnology
@@ -30,24 +31,88 @@ PLACEHOLDER_ROLE = "開発（個人開発）"
 _CATEGORY_ORDER: dict[str, int] = {"language": 0, "framework": 1, "iac": 2}
 
 
-def select_repos(source: DraftSource, limit: int = PROJECT_LIMIT) -> list:
-    """ドラフトに載せるリポジトリを決定論的に選定する。
+NOISE_REASON_SHORT_LIVED = "継続期間が短い"
+NOISE_REASON_LEARNING_TOPIC = "学習用途の topics"
 
-    第 1 キー: 最終 push 日時の降順（直近の活動を優先）
-    第 2 キー: 言語バイト合計の降順（実装量の多いリポを優先）
-    タイブレーク: full_name の辞書順（決定論の担保）
+# これ未満の継続期間はデフォルト非選択にする。チュートリアル・写経は数日〜数週で
+# 終わるため、1 ヶ月継続を「作り込んだ」の下限とする（ADR-0026 決定 3）
+_SHORT_LIVED_THRESHOLD_DAYS = 30
+
+# 学習用途を示す topics（正規化後の完全一致で判定する）
+_LEARNING_TOPICS = frozenset(
+    {
+        "tutorial", "practice", "sample", "study", "learning", "handson",
+        "example", "demo", "playground", "boilerplate",
+    }
+)
+
+
+@dataclass(frozen=True)
+class NoiseVerdict:
+    """デフォルト選択状態と、非選択にした理由（ADR-0026 決定 2）。
+
+    **機械は候補を落とさない**。本判定は UI のデフォルト選択状態と理由表示にのみ
+    影響させ、``select_repos`` の結果からは除外しない。価値判断は人間が行う。
     """
 
-    def language_bytes_total(full_name: str) -> int:
-        return sum(
-            tech.language_bytes for tech in source.repo_technologies.get(full_name, [])
-        )
+    selected_by_default: bool
+    # frozen の不変性を実際に担保するため tuple にする（list だと要素を書き換えられる）
+    reasons: tuple[str, ...]
 
+
+def _normalize_topic(topic: str) -> str:
+    """topics を比較用に正規化する（小文字化 + 区切り除去）。
+
+    ``hands-on`` / ``Hands_On`` / ``HANDSON`` を同一視する。部分一致は採らない
+    （``sample-api-server`` のような本命を誤判定するため）。
+    """
+    return topic.lower().replace("-", "").replace("_", "")
+
+
+def evaluate_noise(repo, *, threshold_days: int = _SHORT_LIVED_THRESHOLD_DAYS) -> NoiseVerdict:
+    """デフォルト非選択にすべきリポジトリかを判定する（ADR-0026 決定 2・3）。
+
+    ``threshold_days`` はテストからの注入用（``build_skeleton(today=...)`` と同じ流儀）。
+    理由は判定順に積むため、同じ入力からは常に同じ並びで返る。
+    """
+    reasons: list[str] = []
+    if _active_days(repo) < threshold_days:
+        reasons.append(NOISE_REASON_SHORT_LIVED)
+    if any(_normalize_topic(topic) in _LEARNING_TOPICS for topic in repo.topics):
+        reasons.append(NOISE_REASON_LEARNING_TOPIC)
+    return NoiseVerdict(selected_by_default=not reasons, reasons=tuple(reasons))
+
+
+def _active_days(repo) -> int:
+    """継続期間（created_at → pushed_at の日数）。不正・空の日付は 0 とする。
+
+    チュートリアル・写経は数日で終わり、実プロジェクトは数ヶ月〜数年継続するため、
+    単一シグナルとしての判別力が最も高い（ADR-0026 決定 3）。
+    """
+    try:
+        created = date.fromisoformat(repo.created_at[:10])
+        pushed = date.fromisoformat(repo.pushed_at[:10])
+    except ValueError:
+        return 0
+    return max((pushed - created).days, 0)
+
+
+def select_repos(source: DraftSource, limit: int = PROJECT_LIMIT) -> list:
+    """ドラフトに載せるリポジトリを決定論的に選定する（ADR-0026 決定 3）。
+
+    第 1 キー: 継続期間の降順（作り込んで続けたリポを優先）
+    第 2 キー: 言語バイト合計の降順（実装量の多いリポを優先）
+    第 3 キー: 最終 push 日時の降順（直近性はタイブレークへ降格）
+    最終タイブレーク: full_name の辞書順（決定論の担保）
+
+    継続期間と実装量は重み付けせず段階比較する。積や重み付き和は係数の恣意性が
+    入り、「継続 1000 日 × 1KB」と「10 日 × 100KB」が並んでしまう。
+    """
     # 安定ソートを重ねて「タイブレーク昇順 → 主キー群降順」を実現する
     repos = sorted(source.repos, key=lambda r: r.full_name)
     repos = sorted(
         repos,
-        key=lambda r: (r.pushed_at, language_bytes_total(r.full_name)),
+        key=lambda r: (_active_days(r), r.language_bytes_total, r.pushed_at),
         reverse=True,
     )
     return repos[:limit]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,6 +74,7 @@ source_paths = ["app"]
 only_mutate = [
     "app/services/agent/rate_limit.py",                   # Agent 日次レート制限判定（#521）
     "app/services/agent/resume_import/text_extract.py",   # PDF テキスト抽出・スキャン判定（#527 / ADR-0024）
+    "app/services/agent/resume_draft/mapper.py",          # ドラフト選定順・ノイズ判定（#562 / ADR-0026）
     "app/services/intelligence/skills/*",                 # スキル推論（aggregator/linguist/パーサ群）
     "app/services/intelligence/github/repo_analyzer.py",  # リポジトリ解析
     "app/services/intelligence/github/contributions.py",  # コントリビューション集計

--- a/backend/tests/test_resume_draft_mapper.py
+++ b/backend/tests/test_resume_draft_mapper.py
@@ -21,10 +21,13 @@ from app.services.agent.resume_draft.context import (
     build_draft_source,
 )
 from app.services.agent.resume_draft.mapper import (
+    NOISE_REASON_LEARNING_TOPIC,
+    NOISE_REASON_SHORT_LIVED,
     PLACEHOLDER_COMPANY,
     PROJECT_LIMIT,
     STACK_LIMIT_PER_PROJECT,
     build_skeleton,
+    evaluate_noise,
     select_repos,
 )
 
@@ -32,10 +35,12 @@ _TODAY = date(2026, 7, 1)
 
 
 def _repo(full_name: str, *, description: str = "", created: str = "2023-01-15T00:00:00Z",
-          pushed: str = "2026-06-01T00:00:00Z") -> AnalyzedRepoSummary:
+          pushed: str = "2026-06-01T00:00:00Z", topics: list[str] | None = None,
+          language_bytes: int = 0) -> AnalyzedRepoSummary:
     """テスト用のリポジトリサマリを生成する。"""
     return AnalyzedRepoSummary(
-        full_name=full_name, description=description, created_at=created, pushed_at=pushed
+        full_name=full_name, description=description, created_at=created, pushed_at=pushed,
+        topics=topics or [], language_bytes_total=language_bytes,
     )
 
 
@@ -54,41 +59,154 @@ def _source(repos: list, technologies: dict | None = None) -> DraftSource:
 # ---------------------------------------------------------------------------
 
 
-def test_select_repos_orders_by_pushed_at_desc() -> None:
-    """第 1 キーは最終 push 日時の降順。"""
+def test_select_repos_ranks_long_lived_over_recently_touched() -> None:
+    """第 1 キーは継続期間（ADR-0026 決定 3）。
+
+    「昨日 README を直しただけのチュートリアル」が「作り込んで完成させた本命」に
+    勝つのを防ぐ。直近性は主キーから外す。
+    """
     source = _source(
         [
-            _repo("o/old", pushed="2024-01-01T00:00:00Z"),
-            _repo("o/new", pushed="2026-06-01T00:00:00Z"),
-            _repo("o/mid", pushed="2025-06-01T00:00:00Z"),
+            # 3 日で終わったが昨日 push（チュートリアル型）
+            _repo("o/tutorial", created="2026-06-25T00:00:00Z", pushed="2026-06-30T00:00:00Z"),
+            # 2 年継続。最終 push は半年前（本命型）
+            _repo("o/flagship", created="2024-01-01T00:00:00Z", pushed="2026-01-01T00:00:00Z"),
         ]
     )
-    assert [r.full_name for r in select_repos(source)] == ["o/new", "o/mid", "o/old"]
+    assert [r.full_name for r in select_repos(source)] == ["o/flagship", "o/tutorial"]
 
 
-def test_select_repos_tiebreaks_by_language_bytes_then_name() -> None:
-    """push 日時が同じなら言語バイト合計の降順、それも同じなら名前の辞書順。"""
-    pushed = "2026-06-01T00:00:00Z"
+def test_select_repos_tiebreaks_by_language_bytes() -> None:
+    """継続期間が同じなら実装量（言語バイト合計）の降順。"""
     source = _source(
-        [_repo("o/small", pushed=pushed), _repo("o/big", pushed=pushed),
-         _repo("o/b-zero", pushed=pushed), _repo("o/a-zero", pushed=pushed)],
-        technologies={
-            "o/small": [RepoTechnology("language", "Python", 0.9, language_bytes=100)],
-            "o/big": [RepoTechnology("language", "Python", 0.9, language_bytes=9000)],
-        },
+        [
+            _repo("o/small", language_bytes=100),
+            _repo("o/big", language_bytes=9000),
+            _repo("o/mid", language_bytes=3000),
+        ]
     )
-    assert [r.full_name for r in select_repos(source)] == [
-        "o/big", "o/small", "o/a-zero", "o/b-zero",
+    assert [r.full_name for r in select_repos(source)] == ["o/big", "o/mid", "o/small"]
+
+
+def test_select_repos_tiebreaks_by_pushed_at_after_bytes() -> None:
+    """継続期間・実装量が同じなら最終 push が新しい方が上位（直近性は第 3 キー）。"""
+    source = _source(
+        [
+            # 継続 365 日・実装量 500 で揃え、push 日時だけ変える
+            _repo("o/stale", created="2025-01-01T00:00:00Z", pushed="2026-01-01T00:00:00Z",
+                  language_bytes=500),
+            _repo("o/fresh", created="2025-06-01T00:00:00Z", pushed="2026-06-01T00:00:00Z",
+                  language_bytes=500),
+        ]
+    )
+    assert [r.full_name for r in select_repos(source)] == ["o/fresh", "o/stale"]
+
+
+def test_select_repos_is_totally_ordered_by_name() -> None:
+    """全キー同値でも full_name の辞書順で並びが一意に決まる（完全順序）。"""
+    repos = [_repo("o/c"), _repo("o/a"), _repo("o/b")]
+    assert [r.full_name for r in select_repos(_source(repos))] == ["o/a", "o/b", "o/c"]
+    # 入力順を変えても同じ並びになること（同一入力 → 同一出力の不変条件）
+    assert [r.full_name for r in select_repos(_source(list(reversed(repos))))] == [
+        "o/a", "o/b", "o/c",
     ]
+
+
+def test_select_repos_treats_invalid_dates_as_zero_duration() -> None:
+    """日付が不正・空でも例外にならず、継続期間 0 として下位に落ちる。"""
+    source = _source(
+        [
+            _repo("o/broken", created="", pushed=""),
+            _repo("o/invalid", created="not-a-date", pushed="2026-06-01T00:00:00Z"),
+            _repo("o/valid", created="2025-01-01T00:00:00Z", pushed="2026-01-01T00:00:00Z"),
+        ]
+    )
+    assert [r.full_name for r in select_repos(source)][0] == "o/valid"
 
 
 def test_select_repos_caps_at_project_limit() -> None:
     """上限件数（PROJECT_LIMIT）で打ち切る。"""
-    repos = [_repo(f"o/repo-{i}", pushed=f"2026-01-{i + 1:02d}T00:00:00Z") for i in range(8)]
+    repos = [
+        _repo(f"o/repo-{i}", created="2024-01-01T00:00:00Z",
+              pushed=f"2024-0{i + 1}-01T00:00:00Z")
+        for i in range(8)
+    ]
     selected = select_repos(_source(repos))
     assert len(selected) == PROJECT_LIMIT
-    # 直近 push 順に上位が選ばれている
+    # 継続期間が最も長いもの（最後に push されたもの）が先頭
     assert selected[0].full_name == "o/repo-7"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_noise: デフォルト非選択の判定（ADR-0026 決定 2・3）
+#
+# 機械は候補を落とさない。判定はデフォルト選択状態と理由表示にのみ影響させる。
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_noise_flags_short_lived_repo() -> None:
+    """継続期間が閾値未満なら非選択 + 理由を返す。"""
+    repo = _repo("o/tutorial", created="2026-06-25T00:00:00Z", pushed="2026-06-30T00:00:00Z")
+    verdict = evaluate_noise(repo)
+    assert verdict.selected_by_default is False
+    assert NOISE_REASON_SHORT_LIVED in verdict.reasons
+
+
+def test_evaluate_noise_flags_learning_topics() -> None:
+    """topics に学習用途語があれば非選択 + 理由を返す。"""
+    repo = _repo("o/app", topics=["python", "tutorial"])
+    verdict = evaluate_noise(repo)
+    assert verdict.selected_by_default is False
+    assert NOISE_REASON_LEARNING_TOPIC in verdict.reasons
+
+
+def test_evaluate_noise_normalizes_topic_notation() -> None:
+    """topics は小文字化 + 区切り除去して完全一致で判定する。"""
+    # hands-on / Hands_On / HANDSON はいずれも学習用途語として扱う
+    for topic in ("hands-on", "Hands_On", "HANDSON"):
+        assert evaluate_noise(_repo("o/app", topics=[topic])).selected_by_default is False
+    # 部分一致では落とさない（本命が学習用途と誤判定されるのを防ぐ）
+    assert evaluate_noise(_repo("o/app", topics=["sample-api-server"])).selected_by_default
+
+
+def test_evaluate_noise_returns_all_applicable_reasons() -> None:
+    """複数該当なら理由を全て返す（順序も決定論）。"""
+    repo = _repo(
+        "o/study", created="2026-06-25T00:00:00Z", pushed="2026-06-30T00:00:00Z",
+        topics=["study"],
+    )
+    verdict = evaluate_noise(repo)
+    assert verdict.reasons == (NOISE_REASON_SHORT_LIVED, NOISE_REASON_LEARNING_TOPIC)
+
+
+def test_evaluate_noise_selects_substantial_repo() -> None:
+    """閾値以上かつ学習用途語なしならデフォルト選択（理由は空）。"""
+    repo = _repo("o/flagship", created="2024-01-01T00:00:00Z", pushed="2026-01-01T00:00:00Z",
+                 topics=["fastapi"])
+    verdict = evaluate_noise(repo)
+    assert verdict.selected_by_default is True
+    assert verdict.reasons == ()
+
+
+def test_evaluate_noise_threshold_is_inclusive_lower_bound() -> None:
+    """継続期間がちょうど閾値ならデフォルト選択（閾値「未満」が非選択）。"""
+    # threshold_days=30 に対し、継続 30 日 = 選択 / 29 日 = 非選択
+    exactly = _repo("o/exact", created="2026-06-01T00:00:00Z", pushed="2026-07-01T00:00:00Z")
+    just_under = _repo("o/under", created="2026-06-02T00:00:00Z", pushed="2026-07-01T00:00:00Z")
+    assert evaluate_noise(exactly, threshold_days=30).selected_by_default is True
+    assert evaluate_noise(just_under, threshold_days=30).selected_by_default is False
+
+
+def test_evaluate_noise_does_not_drop_candidates() -> None:
+    """ノイズ判定は select_repos の結果件数を変えない（機械は候補を落とさない）。"""
+    repos = [
+        _repo("o/tutorial", created="2026-06-25T00:00:00Z", pushed="2026-06-30T00:00:00Z",
+              topics=["tutorial"]),
+        _repo("o/flagship", created="2024-01-01T00:00:00Z", pushed="2026-01-01T00:00:00Z"),
+    ]
+    selected = select_repos(_source(repos))
+    assert len(selected) == 2
+    assert "o/tutorial" in [r.full_name for r in selected]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #562

## 概要

ADR-0026 決定 3。`select_repos` の第 1 キーが**最終 push 日時の降順**だったため、「昨日 README を直しただけのチュートリアル」が「半年前に作り込んで完成させた本命」に勝っていた。チュートリアル・todo アプリ・写経リポジトリが上位を占めうる状態を解消する。

## 変更内容

### 1. 選定順（`select_repos`）

| 順位 | キー | 変更 |
|---|---|---|
| 第 1 | 継続期間（`pushed_at − created_at`） | **新規**。主キー |
| 第 2 | `language_bytes_total` | #561 の永続化値を参照（`repo_technologies` からの都度算出をやめた） |
| 第 3 | `pushed_at` | 主キー → **タイブレークへ降格** |
| 最終 | `full_name` 昇順 | 現行の決定論保証を引き継ぎ |

**重み付き和や積は採らなかった**。係数の恣意性が入り、「継続 1000 日 × 1KB」と「10 日 × 100KB」が並んでしまう。段階比較なら「まず続いたか、次に作り込んだか」という判断順を素直に表せる。

**stars は使わない**（ADR-0026 決定 3。個人開発では本命でも 0〜1 が普通で判別力が無い）。

### 2. ノイズ判定（`evaluate_noise` / 新規）

`NoiseVerdict(selected_by_default: bool, reasons: tuple[str, ...])` を返す純関数。

- 継続期間が閾値（30 日）未満 → 理由「継続期間が短い」
- topics に学習用途語 → 理由「学習用途の topics」
- 複数該当なら理由を全て返す（順序も決定論）

topics は**小文字化 + 区切り除去して完全一致**で判定する。`hands-on` / `Hands_On` / `HANDSON` を同一視しつつ、部分一致は採らない（`sample-api-server` のような本命を誤判定するため）。

**機械は候補を落とさない**（ADR-0026 決定 2）。本判定は UI のデフォルト選択状態と理由表示にのみ影響させ、`select_repos` の結果からは除外しない。専用テストで「判定が結果件数を変えない」ことを固定している。

### 3. 定義事項

issue が「本 issue で定義しテストで固定する」としていた項目を確定した。**正本は `mapper.py` の定数で、ADR に数値は複製していない**。

| 項目 | 決定 |
|---|---|
| スコア式 | 重み付けせずタプルの段階比較 |
| 実装量 | `language_bytes_total`（単一フィールド・重みなし） |
| 継続期間の閾値 | 30 日未満を非選択（テストから `threshold_days=` で注入可） |
| 学習用途 topics | `tutorial` `practice` `sample` `study` `learning` `handson` `example` `demo` `playground` `boilerplate` |
| 正規化 | 小文字化 + `-` `_` 除去 → 完全一致 |
| 完全順序 | 全キー同値でも `full_name` 昇順で一意 |

### 4. mutmut スコープ

`backend/pyproject.toml` の `[tool.mutmut] only_mutate` に `resume_draft/mapper.py` を追加した。以降この経路は `make lint-tdd` の対象になる。

## TDD（ADR-0019）

2 サイクル実施し、いずれも red の失敗出力を確認してから実装した。

| サイクル | red の失敗 |
|---|---|
| 並び順 | `At index 0 diff: 'o/tutorial' != 'o/flagship'` |
| ノイズ判定 | `assert True is False` / `assert [] == ['継続期間が短い', '学習用途の topics']` |

2 サイクル目は関数未定義で collection error になったため、`.claude/rules/common/tdd.md` の指示（collection error はテスト自体の不備）に従い最小スタブを置き直し、**振る舞いで落ちる red** を確認してから green へ進んでいる。

テストは 30 件 pass。旧契約（`pushed_at` 第 1 キー）を固定していた既存テスト 2 件は新契約へ置き換え、旧契約を固定化したテストは残していない。

## 検証

- `make ci`（`lint-tdd` 含む）: pass

## 注意点

- **`evaluate_noise` は現時点で呼び出し元が無い**。issue #562 の作業項目として先行実装しており、消費するのは #564（候補一覧 API）・#565（選択 UI）
- **選定結果が変わる**。既存ユーザーのドラフトに載るリポジトリが入れ替わる（ADR-0026 の意図どおり）
- `_LEARNING_TOPICS` に `sample` / `demo` / `example` を含めたため、これらを付けた本命が誤ってデフォルト非選択になりうる。ただし**候補からは落ちず**理由も表示されるので人間が覆せる。語彙は運用してからの方が精度が出るため現時点では調整しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved repository selection to prioritize sustained activity, language usage, recent updates, and consistent name ordering.
  * Added clearer handling for repositories with invalid dates and short-lived activity.
  * Repositories focused on learning or experimentation can now be identified and excluded by default.
  * Added configurable thresholds and consistent, understandable reasons for repository selection decisions.
  * Preserved eligible repositories when applying selection limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->