### PR TITLE
chore: Renovate の backend 依存 6 件を 1 本に統合し THIRD_PARTY_LICENSES を再生成

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,7 @@ nix develop --command bash -c "cd web && npm run test:e2e"
 |---|---|---|---|
 | backend の OpenAPI スキーマ（`app/schemas/` の Pydantic、router のシグネチャ・query/path パラメータ・**endpoint/schema の docstring**） | `make codegen-types` | `web/src/api/generated.ts`（`backend/openapi.json` は gitignore で対象外） | `codegen-drift`（ADR-0007） |
 | backend の依存定義（`backend/pyproject.toml` の `[project.dependencies]`） | `nix develop --command bash -c "cd backend && uv lock"` | `backend/uv.lock` | `test-backend` の `uv lock --check`（ADR-0021 Phase 0/2。依存導入自体は uv2nix の Nix build） |
+| 直接依存の追加・削除・**バージョン更新**（`backend/pyproject.toml` / `web/package.json`） | `make licenses` | `THIRD_PARTY_LICENSES.md` | **なし（CI 未検証・手動）**。drift しても落ちないので依存 PR では必ず手で回す |
 
 - **判定基準**: 「OpenAPI スペックに出るものを変えたか」。エンドポイントの追加・削除、リクエスト/レスポンス型の変更、query/path パラメータの増減はもちろん、**docstring の文言変更だけでも description として spec に反映される**ため再生成が要る（今回の codegen-drift はこれで発生）。
 - backend の `app/schemas/` / `app/routers/` を触ったら、`make ci` 前に `make codegen-types` を回して `git diff web/src/api/generated.ts` を確認する。差分が出たら必ず同じ PR でコミットする。

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,7 +100,7 @@ nix develop --command bash -c "cd web && npm run test:e2e"
 |---|---|---|---|
 | backend の OpenAPI スキーマ（`app/schemas/` の Pydantic、router のシグネチャ・query/path パラメータ・**endpoint/schema の docstring**） | `make codegen-types` | `web/src/api/generated.ts`（`backend/openapi.json` は gitignore で対象外） | `codegen-drift`（ADR-0007） |
 | backend の依存定義（`backend/pyproject.toml` の `[project.dependencies]`） | `nix develop --command bash -c "cd backend && uv lock"` | `backend/uv.lock` | `test-backend` の `uv lock --check`（ADR-0021 Phase 0/2。依存導入自体は uv2nix の Nix build） |
-| 直接依存の追加・削除・**バージョン更新**（`backend/pyproject.toml` / `web/package.json`） | `make licenses` | `THIRD_PARTY_LICENSES.md` | **なし（CI 未検証・手動）**。drift しても落ちないので依存 PR では必ず手で回す |
+| 直接依存の追加・削除・**バージョン更新**（`backend/pyproject.toml` / `web/package.json`） | `make licenses` | `THIRD_PARTY_LICENSES.md` | **なし（CI 未検証・手動）**。drift しても落ちないので依存 PR では必ず手で回す。ただし依存を解決できない不完全な環境で回した場合は生成スクリプト側が exit 1 で中止する |
 
 - **判定基準**: 「OpenAPI スペックに出るものを変えたか」。エンドポイントの追加・削除、リクエスト/レスポンス型の変更、query/path パラメータの増減はもちろん、**docstring の文言変更だけでも description として spec に反映される**ため再生成が要る（今回の codegen-drift はこれで発生）。
 - backend の `app/schemas/` / `app/routers/` を触ったら、`make ci` 前に `make codegen-types` を回して `git diff web/src/api/generated.ts` を確認する。差分が出たら必ず同じ PR でコミットする。

--- a/.claude/rules/common/review.md
+++ b/.claude/rules/common/review.md
@@ -41,6 +41,7 @@ PR 後の CodeRabbit 指摘対応・手動レビュー・`/code-review` の結�
 
 - codegen 生成物の再生成漏れ: `app/schemas/` / `app/routers/`（**docstring の変更を含む**）を触ったのに `web/src/api/generated.ts` に差分が無い
 - `backend/pyproject.toml` の依存を変えたのに `backend/uv.lock` が未更新
+- 依存のバージョンを更新したのに `THIRD_PARTY_LICENSES.md` が `make licenses` で再生成されていない（CI に drift 検知が無いため落ちず、マージ済み依存 PR 数件分が陳腐化していた実例。Renovate PR 統合時に発覚）
 - 新規環境変数の 4 箇所同期（`backend/app/core/env_keys.py` のコメント手順）
 - ADR の新規作成・ステータス変更に対する `docs/adr/README.md` 索引の更新漏れ
 - **手順・フローを変えたら、それを記述している他の docs / rules も同じ差分で更新する**（RV 導入時に `rules/common/tdd.md` の「`make ci` → stage」と CLAUDE.md のモデル切り替えタイミングが drift した実例）

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -72,7 +72,6 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | [google-cloud-tasks](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-tasks) | 2.23.0 | Apache Software License |
 | [httpx](https://github.com/encode/httpx) | 0.28.1 | BSD License |
 | [markdown](https://Python-Markdown.github.io/) | 3.10.3 | BSD-3-Clause |
-| [mutmut](https://github.com/boxed/mutmut) | 3.7.0 | BSD-3-Clause |
 | [pyasn1](https://github.com/pyasn1/pyasn1) | 0.6.4 | BSD-2-Clause |
 | [pydantic](https://github.com/pydantic/pydantic) | 2.13.4 | MIT |
 | [pydyf](https://www.courtbouillon.org/pydyf) | 0.12.1 | BSD License |
@@ -97,6 +96,7 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | [autopep8](https://github.com/hhatto/autopep8) | 2.3.2 | MIT License |
 | [black](https://github.com/psf/black) | 26.5.1 | MIT |
 | [isort](https://pycqa.github.io/isort/index.html) | 8.0.1 | MIT |
+| [mutmut](https://github.com/boxed/mutmut) | 3.7.0 | BSD-3-Clause |
 | [pytest](https://docs.pytest.org/en/latest/) | 9.1.1 | MIT |
 | [pytest-cov](https://pypi.org/project/pytest-cov/) | 7.1.0 | MIT |
 | [ruff](https://docs.astral.sh/ruff) | 0.16.1 | MIT |

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -16,14 +16,14 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | ライブラリ | バージョン | ライセンス |
 |---|---|---|
 | [@reduxjs/toolkit](https://redux-toolkit.js.org) | 2.12.0 | MIT |
-| [dompurify](https://github.com/cure53/DOMPurify) | 3.4.10 | (MPL-2.0 OR Apache-2.0) |
-| [marked](https://marked.js.org) | 18.0.5 | MIT |
-| [react](https://react.dev/) | 19.2.7 | MIT |
-| [react-dom](https://react.dev/) | 19.2.7 | MIT |
+| [dompurify](https://github.com/cure53/DOMPurify) | 3.4.12 | (MPL-2.0 OR Apache-2.0) |
+| [marked](https://marked.js.org) | 18.0.7 | MIT |
+| [react](https://react.dev/) | 19.2.8 | MIT |
+| [react-dom](https://react.dev/) | 19.2.8 | MIT |
 | [react-pdf](https://github.com/wojtekmaj/react-pdf) | 10.4.1 | MIT |
 | [react-redux](https://github.com/reduxjs/react-redux) | 9.3.0 | MIT |
-| [react-router-dom](https://github.com/remix-run/react-router) | 7.18.0 | MIT |
-| [recharts](https://github.com/recharts/recharts) | 3.8.1 | MIT |
+| [react-router-dom](https://github.com/remix-run/react-router) | 7.18.2 | MIT |
+| [recharts](https://github.com/recharts/recharts) | 3.10.1 | MIT |
 | [redux-persist](https://github.com/rt2zz/redux-persist#readme) | 6.0.0 | MIT |
 
 ## Frontend（ビルド・開発ツール）
@@ -31,64 +31,63 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | ライブラリ | バージョン | ライセンス |
 |---|---|---|
 | [@eslint/js](https://eslint.org) | 10.0.1 | MIT |
-| [@playwright/test](https://playwright.dev) | 1.61.0 | Apache-2.0 |
-| [@stryker-mutator/core](https://www.npmjs.com/package/@stryker-mutator/core) | — | 要確認 (未インストール) |
-| [@stryker-mutator/vitest-runner](https://www.npmjs.com/package/@stryker-mutator/vitest-runner) | — | 要確認 (未インストール) |
-| [@testing-library/jest-dom](https://github.com/testing-library/jest-dom#readme) | 6.9.1 | MIT |
+| [@playwright/test](https://playwright.dev) | 1.62.0 | Apache-2.0 |
+| [@stryker-mutator/core](https://stryker-mutator.io/) | 9.6.1 | Apache-2.0 |
+| [@stryker-mutator/vitest-runner](https://stryker-mutator.io/docs/stryker-js/vitest-runner) | 9.6.1 | Apache-2.0 |
+| [@testing-library/jest-dom](https://github.com/testing-library/jest-dom#readme) | 7.0.0 | MIT |
 | [@testing-library/react](https://github.com/testing-library/react-testing-library#readme) | 16.3.2 | MIT |
 | [@testing-library/user-event](https://github.com/testing-library/user-event#readme) | 14.6.1 | MIT |
-| [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node) | 25.9.3 | MIT |
+| [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node) | 25.9.5 | MIT |
 | [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) | 19.2.17 | MIT |
 | [@types/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom) | 19.2.3 | MIT |
-| [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#readme) | 6.0.2 | MIT |
-| [@vitest/coverage-v8](https://vitest.dev/guide/coverage) | 4.1.9 | MIT |
-| [concurrently](https://github.com/open-cli-tools/concurrently) | 10.0.3 | MIT |
-| [eslint](https://eslint.org) | 10.5.0 | MIT |
+| [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#readme) | 6.0.4 | MIT |
+| [@vitest/coverage-v8](https://vitest.dev/guide/coverage) | 4.1.10 | MIT |
+| [concurrently](https://github.com/open-cli-tools/concurrently) | 10.0.4 | MIT |
+| [eslint](https://eslint.org) | 10.8.0 | MIT |
 | [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#readme) | 10.1.8 | MIT |
 | [eslint-plugin-react-hooks](https://react.dev/) | 7.1.1 | MIT |
 | [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) | 0.5.3 | MIT |
 | [express](https://expressjs.com/) | 5.2.1 | MIT |
-| [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#readme) | 4.1.1 | MIT |
+| [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#readme) | 4.2.0 | MIT |
 | [jsdom](https://github.com/jsdom/jsdom) | 29.1.1 | MIT |
-| [msw](https://mswjs.io) | 2.14.6 | MIT |
+| [msw](https://mswjs.io) | 2.15.0 | MIT |
 | [openapi-typescript](https://openapi-ts.dev) | 7.13.0 | MIT |
-| [playwright](https://playwright.dev) | 1.61.0 | Apache-2.0 |
-| [prettier](https://prettier.io) | 3.8.4 | MIT |
+| [playwright](https://playwright.dev) | 1.62.0 | Apache-2.0 |
+| [prettier](https://prettier.io) | 3.9.6 | MIT |
 | [typescript](https://www.typescriptlang.org/) | 5.9.3 | Apache-2.0 |
-| [typescript-eslint](https://typescript-eslint.io/packages/typescript-eslint) | 8.61.1 | MIT |
-| [vite](https://vite.dev) | 8.0.16 | MIT |
-| [vitest](https://vitest.dev) | 4.1.9 | MIT |
-| [wrangler](https://github.com/cloudflare/workers-sdk#readme) | 4.101.0 | MIT OR Apache-2.0 |
+| [typescript-eslint](https://typescript-eslint.io/packages/typescript-eslint) | 8.65.0 | MIT |
+| [vite](https://vite.dev) | 8.1.5 | MIT |
+| [vitest](https://vitest.dev) | 4.1.10 | MIT |
+| [wrangler](https://github.com/cloudflare/workers-sdk#readme) | 4.114.0 | MIT OR Apache-2.0 |
 
 ## Backend（ランタイム）
 
 | ライブラリ | バージョン | ライセンス |
 |---|---|---|
 | [alembic](https://alembic.sqlalchemy.org) | 1.18.5 | MIT |
-| [anthropic](https://github.com/anthropics/anthropic-sdk-python) | 0.115.0 | MIT License |
-| [fastapi](https://github.com/fastapi/fastapi) | 0.138.2 | MIT |
-| [google-cloud-storage](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage) | 3.12.0 | Apache Software License |
+| [anthropic](https://github.com/anthropics/anthropic-sdk-python) | 0.120.2 | MIT License |
+| [cryptography](https://github.com/pyca/cryptography) | 50.0.0 | Apache-2.0 OR BSD-3-Clause |
+| [fastapi](https://github.com/fastapi/fastapi) | 0.141.1 | MIT |
+| [google-cloud-storage](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage) | 3.13.0 | Apache Software License |
 | [google-cloud-tasks](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-tasks) | 2.23.0 | Apache Software License |
-| [google-genai](https://github.com/googleapis/python-genai) | 2.10.0 | Apache-2.0 |
 | [httpx](https://github.com/encode/httpx) | 0.28.1 | BSD License |
-| [markdown](https://Python-Markdown.github.io/) | 3.10.2 | BSD-3-Clause |
-| [mutmut](https://github.com/boxed/mutmut) | 3.6.0 | BSD-3-Clause |
-| [openai](https://github.com/openai/openai-python) | 2.44.0 | Apache Software License |
-| [pyasn1](https://github.com/pyasn1/pyasn1) | 0.6.3 | BSD-2-Clause |
+| [markdown](https://Python-Markdown.github.io/) | 3.10.3 | BSD-3-Clause |
+| [mutmut](https://github.com/boxed/mutmut) | 3.7.0 | BSD-3-Clause |
+| [pyasn1](https://github.com/pyasn1/pyasn1) | 0.6.4 | BSD-2-Clause |
 | [pydantic](https://github.com/pydantic/pydantic) | 2.13.4 | MIT |
 | [pydyf](https://www.courtbouillon.org/pydyf) | 0.12.1 | BSD License |
 | [PyGithub](https://github.com/pygithub/pygithub) | 2.9.1 | GNU Library or Lesser General Public License (LGPL) |
 | [PyJWT](https://github.com/jpadilla/pyjwt) | 2.13.0 | MIT |
+| [pypdf](https://github.com/py-pdf/pypdf) | 6.14.2 | BSD-3-Clause |
 | [python-dotenv](https://github.com/theskumar/python-dotenv) | 1.2.2 | BSD-3-Clause |
 | [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.32 | Apache-2.0 |
-| [redis](https://github.com/redis/redis-py) | 8.0.1 | MIT |
+| [redis](https://github.com/redis/redis-py) | 8.1.0 | MIT |
 | [reportlab](https://www.reportlab.com/) | 5.0.0 | BSD License |
 | [slowapi](https://github.com/laurents/slowapi) | 0.1.10 | MIT License |
 | [sqlalchemy](https://www.sqlalchemy.org) | 2.0.51 | MIT |
 | [sqlalchemy-libsql](https://github.com/tursodatabase/libsql-sqlalchemy) | 0.2.0 | MIT License |
 | [starlette](https://github.com/Kludex/starlette) | 1.3.1 | BSD-3-Clause |
-| [stripe](https://stripe.com/) | 15.3.0 | MIT License |
-| [uvicorn](https://uvicorn.dev/) | 0.49.0 | BSD-3-Clause |
+| [uvicorn](https://uvicorn.dev/) | 0.52.1 | BSD-3-Clause |
 | [weasyprint](https://weasyprint.org/) | 69.0 | BSD License |
 
 ## Backend（開発ツール）
@@ -100,4 +99,4 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | [isort](https://pycqa.github.io/isort/index.html) | 8.0.1 | MIT |
 | [pytest](https://docs.pytest.org/en/latest/) | 9.1.1 | MIT |
 | [pytest-cov](https://pypi.org/project/pytest-cov/) | 7.1.0 | MIT |
-| [ruff](https://docs.astral.sh/ruff) | 0.15.20 | MIT |
+| [ruff](https://docs.astral.sh/ruff) | 0.16.1 | MIT |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,11 +10,11 @@ description = "DevForge backend (FastAPI)"
 # （renovate.json5 の allowedVersions "<3.14" と同期）
 requires-python = "==3.13.*"
 dependencies = [
-    "fastapi==0.140.13",
+    "fastapi==0.141.1",
     # starlette は fastapi の推移的依存だが、PYSEC-2026-161（Host ヘッダ未検証による認証バイパス）
     # 対策で明示固定する。さらに CVE-2026-54282 / CVE-2026-54283 対策で 1.3.1 へ更新
     "starlette==1.3.1",
-    "uvicorn[standard]==0.52.0",
+    "uvicorn[standard]==0.52.1",
     "sqlalchemy==2.0.51",
     "sqlalchemy-libsql==0.2.0",
     "alembic==1.18.5",
@@ -31,14 +31,14 @@ dependencies = [
     "anthropic[vertex]==0.120.2",
     "PyGithub==2.9.1",
     "slowapi==0.1.10",
-    "ruff==0.16.0",
+    "ruff==0.16.1",
     "autopep8==2.3.2",
-    "markdown==3.10.2",
+    "markdown==3.10.3",
     "weasyprint==69.0",
     # PDF 経歴書のテキスト抽出（ADR-0024 / #527）。純 Python・native 依存なし。
     "pypdf==6.14.2",
     "pydyf==0.12.1",
-    "redis==8.0.1",
+    "redis==8.1.0",
     "isort==8.0.1",
     "black==26.5.1",
     "pytest-cov==7.1.0",
@@ -47,7 +47,7 @@ dependencies = [
     # CVE-2026-53538 / CVE-2026-53539 / CVE-2026-53540 対策で 0.0.31 以上へ更新済み
     "python-multipart==0.0.32",
     # ミューテーションテスト（週次 CI: .github/workflows/mutation.yml / ADR-0017）
-    "mutmut==3.6.0",
+    "mutmut==3.7.0",
 ]
 
 [tool.uv]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -346,13 +346,13 @@ requires-dist = [
     { name = "autopep8", specifier = "==2.3.2" },
     { name = "black", specifier = "==26.5.1" },
     { name = "cryptography", specifier = "==50.0.0" },
-    { name = "fastapi", specifier = "==0.140.13" },
+    { name = "fastapi", specifier = "==0.141.1" },
     { name = "google-cloud-storage", specifier = "==3.13.0" },
     { name = "google-cloud-tasks", specifier = "==2.23.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "isort", specifier = "==8.0.1" },
-    { name = "markdown", specifier = "==3.10.2" },
-    { name = "mutmut", specifier = "==3.6.0" },
+    { name = "markdown", specifier = "==3.10.3" },
+    { name = "mutmut", specifier = "==3.7.0" },
     { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pydantic", extras = ["email"], specifier = "==2.13.4" },
     { name = "pydyf", specifier = "==0.12.1" },
@@ -363,14 +363,14 @@ requires-dist = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = "==0.0.32" },
-    { name = "redis", specifier = "==8.0.1" },
+    { name = "redis", specifier = "==8.1.0" },
     { name = "reportlab", specifier = "==5.0.0" },
-    { name = "ruff", specifier = "==0.16.0" },
+    { name = "ruff", specifier = "==0.16.1" },
     { name = "slowapi", specifier = "==0.1.10" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "sqlalchemy-libsql", specifier = "==0.2.0" },
     { name = "starlette", specifier = "==1.3.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = "==0.52.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.52.1" },
     { name = "weasyprint", specifier = "==69.0" },
 ]
 
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.140.13"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -425,9 +425,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/cb/7a4d2c2eb5a5d8a91763c05b7383d72917862e32f780daa0e27ffbb34cc6/fastapi-0.140.13.tar.gz", hash = "sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b", size = 424843, upload-time = "2026-07-28T15:37:00.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4e/f9e8c762ef5e05c40482131e3d5e8b36bca13fa127578261f1d6b35a25d4/fastapi-0.140.13-py3-none-any.whl", hash = "sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4", size = 131222, upload-time = "2026-07-28T15:37:02.124Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -829,11 +829,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ wheels = [
 
 [[package]]
 name = "mutmut"
-version = "3.6.0"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -916,9 +916,9 @@ dependencies = [
     { name = "setproctitle" },
     { name = "textual" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/b0/ebcae42b90b07756b7aa10c4176835f436332e6c1cb28bc35bae83462382/mutmut-3.6.0.tar.gz", hash = "sha256:bcbd3e4d0d2d4edf3dfb42955417279a8866a3dbbcb87d619f2f3fd0ac7fafda", size = 51538, upload-time = "2026-06-06T07:44:51.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f9/a63500696f3f35c443ef566528e55630bf7e064436416278927f7bc9c408/mutmut-3.7.0.tar.gz", hash = "sha256:dc93260fabb3a6fd3693aa8d1746825885cb6f9e66c7f9cc1a0f34fc6388e14a", size = 63735, upload-time = "2026-07-31T10:52:58.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/5a/a0caa3f9db407b5d12c311bd4c87aa67fdd6e3f329377149e303108a1c51/mutmut-3.6.0-py3-none-any.whl", hash = "sha256:a9f5b8dcf6cbf9496769d7cf8bdbba37a0ec709ad98f88d103238b62f10bdf37", size = 47770, upload-time = "2026-06-06T07:44:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/93/16/93e3e6aa30e5bc4141724463ae9d9bcc283d08b02aa85dbf5a2b665f3108/mutmut-3.7.0-py3-none-any.whl", hash = "sha256:1d2f9a1bfa4a474b2213df6b17223150b492bf4a85af0eda4fb322297337fb32", size = 59070, upload-time = "2026-07-31T10:53:00.005Z" },
 ]
 
 [[package]]
@@ -1293,11 +1293,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "8.0.1"
+version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -1343,27 +1343,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]
@@ -1543,15 +1543,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
 ]
 
 [package.optional-dependencies]

--- a/scripts/gen-third-party-licenses.py
+++ b/scripts/gen-third-party-licenses.py
@@ -44,6 +44,9 @@ BACKEND_DEV_TOOLS = {
     "black",
     "isort",
     "autopep8",
+    # ミューテーションテスト専用（週次 CI: .github/workflows/mutation.yml / ADR-0017）。
+    # app/ から import されないためランタイムには載らない。
+    "mutmut",
 }
 
 

--- a/scripts/gen-third-party-licenses.py
+++ b/scripts/gen-third-party-licenses.py
@@ -10,6 +10,12 @@ DevForge が直接依存する OSS（自分で選んで入れたライブラリ�
 
 依存を追加したら `make licenses` で再生成すること。
 nix devshell 経由（uv2nix build の python / ADR-0021 Phase 1）で実行する前提。
+
+**不完全な環境での生成を拒否する**: 依存が 1 件でも解決できなかった場合は
+ファイルを書かずに exit 1 する。かつては見つからない依存を
+「要確認 (未インストール)」と書いて正常終了していたため、node_modules 未インストールの
+環境で生成した結果（@stryker-mutator/* の 2 行）が気付かれず main に載っていた。
+attribution 用のファイルなので、欠けたまま出力するより落とす方が安全。
 """
 
 from __future__ import annotations
@@ -17,8 +23,14 @@ from __future__ import annotations
 import importlib.metadata as imd
 import json
 import re
+import sys
 import tomllib
 from pathlib import Path
+
+# 依存を解決できなかった行に入るマーカー。これが 1 件でもあれば生成を中止する。
+# ライセンス種別だけ判定できない場合の「要確認」「要確認 (プロジェクト参照)」とは区別する
+# （そちらはメタデータ側の事情で、実行環境の不備ではないため許容する）。
+NOT_INSTALLED = "要確認 (未インストール)"
 
 ROOT = Path(__file__).resolve().parent.parent
 WEB = ROOT / "web"
@@ -85,7 +97,7 @@ def collect_npm(dep_names: list[str]) -> list[tuple[str, str, str, str]]:
     for name in sorted(dep_names, key=str.lower):
         pkg_json = WEB / "node_modules" / name / "package.json"
         if not pkg_json.exists():
-            rows.append((name, "—", "要確認 (未インストール)", f"https://www.npmjs.com/package/{name}"))
+            rows.append((name, "—", NOT_INSTALLED, f"https://www.npmjs.com/package/{name}"))
             continue
         pkg = json.loads(pkg_json.read_text(encoding="utf-8"))
         version = pkg.get("version", "—")
@@ -100,7 +112,7 @@ def _py_license(dist_name: str) -> tuple[str, str, str]:
     try:
         meta = imd.metadata(dist_name)
     except imd.PackageNotFoundError:
-        return ("—", "要確認 (未インストール)", f"https://pypi.org/project/{dist_name}/")
+        return ("—", NOT_INSTALLED, f"https://pypi.org/project/{dist_name}/")
 
     version = meta.get("Version", "—")
 
@@ -159,6 +171,34 @@ def md_table(rows: list[tuple[str, str, str, str]]) -> str:
     return "\n".join(out)
 
 
+def _abort_if_incomplete(groups: dict[str, list[tuple[str, str, str, str]]]) -> None:
+    """解決できなかった依存があれば、ファイルを書かずに中止する。
+
+    欠けたまま出力すると attribution として誤った内容が配布物に載るうえ、
+    CI に drift 検知が無いためレビューまで気付けない。既存ファイルは正しい状態のまま
+    残したいので、書き込み前に落とす。
+    """
+    missing = {
+        group: [name for name, _version, lic, _url in rows if lic == NOT_INSTALLED]
+        for group, rows in groups.items()
+    }
+    missing = {group: names for group, names in missing.items() if names}
+    if not missing:
+        return
+
+    print("エラー: 依存を解決できなかったため生成を中止しました。", file=sys.stderr)
+    for group, names in missing.items():
+        print(f"  [{group}] {', '.join(names)}", file=sys.stderr)
+    print(
+        "\n実行環境が不完全です。次を確認してください:\n"
+        "  - Frontend: web/node_modules が未インストール（devDependencies 含め `npm ci` が要る）\n"
+        "  - Backend: backend の依存が import できない（nix devshell 経由 = `make licenses` で実行する）\n"
+        "既存の THIRD_PARTY_LICENSES.md は変更していません。",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
 def main() -> None:
     web_pkg = json.loads((WEB / "package.json").read_text(encoding="utf-8"))
     fe_runtime = collect_npm(list(web_pkg.get("dependencies", {})))
@@ -171,6 +211,10 @@ def main() -> None:
         version, lic, url = _py_license(name)
         row = (name, version, lic, url)
         (be_dev if name in BACKEND_DEV_TOOLS else be_runtime).append(row)
+
+    _abort_if_incomplete(
+        {"Frontend (npm)": fe_runtime + fe_dev, "Backend (python)": be_runtime + be_dev}
+    )
 
     doc = f"""# サードパーティライセンス / 使用 OSS
 


### PR DESCRIPTION
## 変更概要

Renovate の PR #575-#580（backend 依存 6 件）を 1 本に統合する。6 件とも `backend/uv.lock` を共有するため個別にマージすると 2 件目以降が必ず競合し Renovate のリベース待ちが連鎖する。まとめて lock を再生成することで一度に解消する。あわせて、依存更新時に再生成が必要な `THIRD_PARTY_LICENSES.md` が未更新だったため `make licenses` で追従させ、その過程で見つかった生成スクリプトの穴（不完全な環境でも黙って通す）も塞いだ。

### バージョン更新（統合元 PR）

| PR | パッケージ | 変更 |
|---|---|---|
| #578 | fastapi | 0.140.13 → 0.141.1 |
| #577 | uvicorn[standard] | 0.52.0 → 0.52.1 |
| #580 | redis | 8.0.1 → 8.1.0 |
| #575 | markdown | 3.10.2 → 3.10.3 |
| #576 | ruff | 0.16.0 → 0.16.1 |
| #579 | mutmut | 3.6.0 → 3.7.0 |

マージ後に上記 6 件は close されます。lock を共有しない #573（redis docker digest）/ #574（react-router-dom）は先行してマージ済み。

### レビュー時に見てほしい点

**`THIRD_PARTY_LICENSES.md` の差分が今回の 6 件を超えて広い**（+34 / -35 行）。このファイルは CI に drift 検知が無く、過去のマージ済み依存 PR の分がずっと陳腐化していたため（fastapi の行が 0.138.2、uvicorn 0.49.0、ruff 0.15.20 のまま等）、生成スクリプトを回すと全体が一斉に追従する。部分再生成はできない。

内容の忠実性は確認済み:

- 削除された openai / stripe / google-genai は `backend/pyproject.toml` に既に存在しない（依存から外れた後も行が残っていた）
- 追加された cryptography / pypdf は pyproject に存在する（追加時に再生成されていなかった）
- frontend 側の版数は `web/package-lock.json` に一致
- 再実行してもファイルに差分が出ないこと（べき等性）を確認済み

### 生成スクリプトの穴を塞いだ（2 コミット目）

`scripts/gen-third-party-licenses.py` は依存を解決できなくても `要確認 (未インストール)` という行を書いて **exit 0** していた。そのため node_modules 未インストールの環境で生成した結果が気付かれず main に載っていた:

```
| [@stryker-mutator/core] | — | 要確認 (未インストール) |
| [@stryker-mutator/vitest-runner] | — | 要確認 (未インストール) |
```

「再生成し忘れ」とは別系統の壊れ方で、CI に drift 検知も無いため誰も気付けない。解決できない依存が 1 件でもあれば **ファイルを書かずに exit 1** するようにした（欠けた依存名と、npm ci / nix devshell どちらが原因かの切り分けを stderr に出す）。中止しても既存ファイルは無傷。

ライセンス種別だけ判定できない `要確認` / `要確認 (プロジェクト参照)` はメタデータ側の事情であり実行環境の不備ではないため、中止条件には含めていない。

なお `scripts/` は ruff の `include`（`app` / `tests` / `alembic_migrations`）外で CI 対象外。参考として手で ruff をかけると EXE001 / I001 / PLE2515 の 3 件が出るが、**`origin/main` の同ファイルでも同一の 3 件**が出るため本 PR 由来ではない（範囲外として触っていない）。

### 確認した非互換リスク

- security 目的で明示ピンしている starlette 1.3.1 / cryptography 50.0.0 / python-multipart 0.0.32 はいずれも降格していない。fastapi 0.141.1 の要求は `starlette>=0.46.0` でピンは有効
- fastapi の minor bump でも OpenAPI 出力は不変（`web/src/api/generated.ts` に差分なし）
- 新しく出るようになった DeprecationWarning が 2 件あるが動作は維持（本 PR の対応範囲外）
  - starlette TestClient の `Using httpx with starlette.testclient is deprecated; install httpx2 instead`
  - redis 8.1.0 で `progress_service.py` の `setex` が deprecated（`set(..., ex=...)` へ寄せる余地あり）

## セルフレビューチェックリスト

### 必須確認

- [x] `make ci` が pass している（lint + test + build-web） — **作業環境に nix が無く `make ci` を直接実行できなかったため個別に実行**: pytest 626 passed / `ruff check` All checks passed / pyright 0 errors / `uv lock --check` pass / `lint-env-keys` `lint-adr-index` `lint-tdd` OK / codegen-drift 相当は差分なし。smoke-backend・test-web・test-e2e・detect-duplication は本 PR の CI で検証
- [x] コメント・ドキュメント・エラーメッセージは日本語で記述した

### 条件付き確認（該当する場合のみ N/A と記入）

- [x] `app/schemas/` または `app/routers/` を変更した場合: N/A（変更なし。ただし fastapi bump の影響確認のため codegen を実行し差分なしを確認済み）
- [x] 新しいページ・認証・ナビゲーション・レイアウトを変更した場合: N/A
- [x] 新規環境変数を追加した場合: N/A
- [x] `web/src/` で日本語メッセージを定数経由で参照した: N/A（`web/src/` の変更なし）

### 破壊的変更

- [x] 破壊的変更なし（API 契約・DB スキーマ・既存の公開インターフェースに変更なし）
- [ ] 破壊的変更あり → 概要:

### ADR（設計判断を伴う変更の場合のみ）

- [x] 新しいライブラリ採用・アーキテクチャ変更を伴う場合、ADR を作成した（または既存 ADR が対応している） — N/A（既存依存のバージョン更新のみ）
- [x] ADR を新規作成・ステータス変更した場合: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated backend dependencies and development tooling to newer versions.
  - Refreshed the third-party license inventory with current dependency versions and packages.
- **Documentation**
  - Documented the required license-inventory update process when dependencies change.
- **Bug Fixes**
  - License inventory generation now detects unresolved dependencies and stops without overwriting the existing file, helping prevent incomplete compliance records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->