### PR TITLE
fix(deps): High 脆弱性 3 件を解消し Renovate PR のブロックを解除（pypdf / nanoid / js-yaml）

### DIFF
--- a/.claude/rules/common/review.md
+++ b/.claude/rules/common/review.md
@@ -43,6 +43,7 @@ PR 後の CodeRabbit 指摘対応・手動レビュー・`/code-review` の結�
 - codegen 生成物の再生成漏れ: `app/schemas/` / `app/routers/`（**docstring の変更を含む**）を触ったのに `web/src/api/generated.ts` に差分が無い
 - `backend/pyproject.toml` の依存を変えたのに `backend/uv.lock` が未更新
 - 依存のバージョンを更新したのに `THIRD_PARTY_LICENSES.md` が `make licenses` で再生成されていない（CI に drift 検知が無いため落ちず、マージ済み依存 PR 数件分が陳腐化していた実例。Renovate PR 統合時に発覚）
+- 脆弱性・警告を恒久解消したら、それを抑制していた allowlist / 無視設定のエントリも同じ差分で削除する（`audit-check.mjs` の ALLOWLIST・`eslint-disable`・`type: ignore` 等。未マッチのエントリは検知されず fail-open のまま残る。js-yaml を override で更新した際に GHSA-52cp のエントリが死に設定として残った実例）
 - 新規環境変数の 4 箇所同期（`backend/app/core/env_keys.py` のコメント手順）
 - ADR の新規作成・ステータス変更に対する `docs/adr/README.md` 索引の更新漏れ
 - **手順・フローを変えたら、それを記述している他の docs / rules も同じ差分で更新する**（RV 導入時に `rules/common/tdd.md` の「`make ci` → stage」と CLAUDE.md のモデル切り替えタイミングが drift した実例）

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -77,7 +77,7 @@ DevForge は多くのオープンソースソフトウェア（OSS）に支え�
 | [pydyf](https://www.courtbouillon.org/pydyf) | 0.12.1 | BSD License |
 | [PyGithub](https://github.com/pygithub/pygithub) | 2.9.1 | GNU Library or Lesser General Public License (LGPL) |
 | [PyJWT](https://github.com/jpadilla/pyjwt) | 2.13.0 | MIT |
-| [pypdf](https://github.com/py-pdf/pypdf) | 6.14.2 | BSD-3-Clause |
+| [pypdf](https://github.com/py-pdf/pypdf) | 6.15.0 | BSD-3-Clause |
 | [python-dotenv](https://github.com/theskumar/python-dotenv) | 1.2.2 | BSD-3-Clause |
 | [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.32 | Apache-2.0 |
 | [redis](https://github.com/redis/redis-py) | 8.1.0 | MIT |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "markdown==3.10.3",
     "weasyprint==69.0",
     # PDF 経歴書のテキスト抽出（ADR-0024 / #527）。純 Python・native 依存なし。
-    "pypdf==6.14.2",
+    "pypdf==6.15.0",
     "pydyf==0.12.1",
     "redis==8.1.0",
     "isort==8.0.1",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -358,7 +358,7 @@ requires-dist = [
     { name = "pydyf", specifier = "==0.12.1" },
     { name = "pygithub", specifier = "==2.9.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
-    { name = "pypdf", specifier = "==6.14.2" },
+    { name = "pypdf", specifier = "==6.15.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -1171,11 +1171,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6242,9 +6242,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7161,9 +7161,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -67,6 +67,7 @@
     "undici": "^7.28.0",
     "fast-uri": "^4.1.2",
     "sharp": "^0.35.3",
-    "brace-expansion": "^5.0.9"
+    "brace-expansion": "^5.0.9",
+    "js-yaml": "^4.3.1"
   }
 }

--- a/web/scripts/audit-check.mjs
+++ b/web/scripts/audit-check.mjs
@@ -27,15 +27,6 @@ const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // 許容する advisory。GHSA ID をキーに、理由と見直し期限を残す。
 // 恒久対応 (vite 8 / Rolldown 移行) 完了時にエントリを削除すること。
 const ALLOWLIST = {
-  "GHSA-52cp-r559-cp3m": {
-    reason:
-      "js-yaml の YAML merge-key チェーンによる二次的 CPU 消費 (DoS)。" +
-      "openapi-typescript(dev 依存) → @redocly/openapi-core 経由の推移的依存で、" +
-      "自前 backend の OpenAPI スキーマ (信頼済み) を codegen する時だけ使用。" +
-      "本番バンドル非到達・攻撃者制御の YAML を parse しない。@redocly/openapi-core は" +
-      "全バージョンが脆弱な js-yaml に依存し npm audit fix でも解消不可のため時限的に許容。",
-    reviewBy: "2026-09-30 (openapi-typescript / @redocly の js-yaml>4.2.0 対応を待つ)",
-  },
   "GHSA-gv7w-rqvm-qjhr": {
     reason:
       "esbuild の Deno モジュール install-time RCE (NPM_CONFIG_REGISTRY 経由)。" +


### PR DESCRIPTION
## 背景

Renovate の PR 8 件（#586〜#593）が **全件** `tests / test-backend` と `tests / test-web` で落ちてマージできない状態だった。

原因はバンプ内容ではなく、`main` に残っていた未対応の High 脆弱性。GitHub Actions の digest 更新しかしていない #587 でも同じ 2 チェックが落ちることから切り分けた。この PR が先にマージされれば Renovate PR 8 件のブロックが解除される。

## 変更内容

| 脆弱性 | 対象 | 対応 |
|---|---|---|
| CVE-2026-71852 / CVE-2026-71870 | pypdf 6.14.2（backend 直接依存） | 6.15.0 へ更新 |
| GHSA-2v37-7h3g-55p8 | nanoid 3.3.16（postcss 経由） | 3.3.18 へ更新（lockfile のみ） |
| GHSA-5p4m-2wfm-xmqj | js-yaml 4.2.0（openapi-typescript → @redocly 経由） | `overrides` で 4.3.1 を強制 |

### js-yaml に overrides を使った理由

`@redocly/openapi-core` が js-yaml を **exact pin（`4.2.0`）** しており、通常の更新では上がらない。`web/package.json` の `overrides` に `js-yaml: ^4.3.1` を追加して解決した。

codegen を壊すリスクがあるため `make codegen-types` を実行し、`web/src/api/generated.ts` に drift が出ないことを確認済み。

### allowlist の死んだエントリを削除

js-yaml が 4.3.1 になったことで `GHSA-52cp-r559-cp3m`（脆弱範囲 `>=4.0.0 <4.3.0`）も恒久解消となったため、`web/scripts/audit-check.mjs` の allowlist から削除した。

`audit-check.mjs` の `reviewBy` 期限強制は **advisory が検出されたときにしか走らない**（未マッチのエントリは `expired` 判定に到達しない）ため、残したままだと死に設定になり、別経路で js-yaml 4.2.x が再混入した際に期限切れ後も静かに握り潰される fail-open になる。

### 随伴する SSoT 更新

- `THIRD_PARTY_LICENSES.md` — 依存バージョン更新に伴い `make licenses` で再生成
- `.claude/rules/common/review.md` — RV で検出した観点を SSoT カテゴリに 1 行追記

## 検証

- `make ci`: pass（EXIT=0。backend/web lint・test 51 files 383 tests・build）
- pip-audit（CI と同一手順）: `No known vulnerabilities found`
- `node web/scripts/audit-check.mjs`: `High/Critical の未許容 advisory はありません。`
- `make codegen-types`: `generated.ts` に drift なし
- RV ループ: Round 2 で High/Medium ゼロ（レポート: `report/RV_20260813_0810.md`）

## レビュー観点

- ロジック変更は一切なく、依存バージョンと監査設定のみ
- pypdf の利用箇所 `app/services/agent/resume_import/text_extract.py`（`PdfReader` / `PyPdfError`）は `tests/test_resume_import_text_extract.py` でカバーされ pass 済み
- js-yaml / nanoid はいずれも dev 依存（codegen・build のみで本番バンドル非到達）

## マージ後

Renovate PR 8 件（#586〜#593）を rebase すれば CI が通る想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled PDF-handling dependency to version 6.15.0.
  * Added a package version override for improved dependency consistency.

* **Security**
  * Removed an obsolete vulnerability exception from dependency auditing.
  * Added guidance to remove outdated warning suppressions once issues are permanently resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->