### PR TITLE
chore: CodeRabbit のレビュー出力を日本語化する設定を追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit 設定（設定項目の正本: https://docs.coderabbit.ai/reference/configuration）
+# まずは最小構成として、レビューコメント・サマリの出力言語のみ日本語に固定する。
+# レビュー観点・重大度の正本は .claude/rules/common/review.md 側にあるため、
+# path_instructions 等でのルール流し込みは必要になった時点で追加する。
+language: "ja-JP"


### PR DESCRIPTION
.coderabbit.yaml を新規追加し、language を ja-JP に固定した。
レビューコメント・サマリが日本語で出るようになる。まずは最小構成とし、
path_instructions 等でのレビュー観点の流し込みは行っていない。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YRzbCMKLbummoPLty8r7gQ